### PR TITLE
Integrate flash-attn-4 (CuTeDSL); add torch.compile-compatible GQA wrapper

### DIFF
--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Tuple
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
-from flash_attn import flash_attn_func
 from torch import nn
 
 from pithtrain.dualpipe.execution import (
@@ -28,6 +27,7 @@ from pithtrain.layers.factory import (
 from pithtrain.models.interface import ForwardAttnOutput
 from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
+from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
 from pithtrain.operators.token_scatter import precompute_group_indices, scatter_for_grouped_gemm
 

--- a/pithtrain/operators/flash_attn_v4.py
+++ b/pithtrain/operators/flash_attn_v4.py
@@ -1,0 +1,59 @@
+"""
+Flash Attention 4 (CuTeDSL) custom_op wrapper for GQA.
+
+Wraps FA4's internal _flash_attn_fwd/_flash_attn_bwd with torch.library.custom_op
+so that torch.compile can trace through them.
+
+Layout: BSHD (batch, sequence, heads, head_dim).
+"""
+
+from typing import Tuple
+
+import torch
+from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
+
+# fmt: off
+# mypy: ignore-errors
+
+@torch.library.custom_op("pithtrain::flash_attn_fa4_fwd", mutates_args=())
+def _flash_attn_fa4_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float, causal: bool) -> Tuple[torch.Tensor, torch.Tensor]:
+    o, lse = _flash_attn_fwd(q, k, v, softmax_scale=softmax_scale, causal=causal, return_lse=True)
+    return o, lse
+
+@_flash_attn_fa4_fwd.register_fake
+def _(q, k, v, softmax_scale, causal):
+    (b, s, h, d) = q.shape
+    o = torch.empty((b, s, h, d), dtype=q.dtype, device=q.device)
+    lse = torch.empty((b, h, s), dtype=torch.float32, device=q.device)
+    return o, lse
+
+@torch.library.custom_op("pithtrain::flash_attn_fa4_bwd", mutates_args=())
+def _flash_attn_fa4_bwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, o: torch.Tensor, lse: torch.Tensor, do: torch.Tensor, softmax_scale: float, causal: bool) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    dq, dk, dv = _flash_attn_bwd(q, k, v, o, do, lse, softmax_scale=softmax_scale, causal=causal)
+    return dq, dk, dv
+
+@_flash_attn_fa4_bwd.register_fake
+def _(q, k, v, o, lse, do, softmax_scale, causal):
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(v)
+    return dq, dk, dv
+
+def _setup_context(ctx, inputs, output):
+    q, k, v, softmax_scale, causal = inputs
+    o, lse = output
+    ctx.save_for_backward(q, k, v, o, lse)
+    ctx.softmax_scale = softmax_scale
+    ctx.causal = causal
+
+def _backward(ctx, grad_o, grad_lse):
+    q, k, v, o, lse = ctx.saved_tensors
+    dq, dk, dv = _flash_attn_fa4_bwd(q, k, v, o, lse, grad_o, ctx.softmax_scale, ctx.causal)
+    return dq, dk, dv, None, None
+
+_flash_attn_fa4_fwd.register_autograd(_backward, setup_context=_setup_context)
+
+def flash_attn_func(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float, causal: bool = False) -> torch.Tensor:
+    """Drop-in replacement for flash_attn.cute.flash_attn_func, compatible with torch.compile."""
+    o, _ = _flash_attn_fa4_fwd(q, k, v, softmax_scale, causal)
+    return o

--- a/pithtrain/operators/ring_attention/standard.py
+++ b/pithtrain/operators/ring_attention/standard.py
@@ -23,7 +23,7 @@ Known limitations
 
 import torch
 import torch.distributed as dist
-from flash_attn.flash_attn_interface import _flash_attn_backward, _flash_attn_forward
+from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
 
 
 def _ring_send_recv_kv(
@@ -88,8 +88,8 @@ class RingAttentionFunc(torch.autograd.Function):
 
             if kv_rank <= cp_rank:
                 use_causal = kv_rank == cp_rank
-                step_out, step_lse, _, _ = _flash_attn_forward(
-                    q, cur_k, cur_v, 0.0, softmax_scale, use_causal, -1, -1, 0.0, None, False
+                step_out, step_lse = _flash_attn_fwd(
+                    q, cur_k, cur_v, softmax_scale=softmax_scale, causal=use_causal, return_lse=True
                 )
                 combined_out, combined_lse = _online_softmax_combine(
                     combined_out, combined_lse, step_out, step_lse
@@ -128,28 +128,15 @@ class RingAttentionFunc(torch.autograd.Function):
         remote_dk, remote_dv = {}, {}
 
         for i, kv_rank in enumerate(ctx.saved_ranks):
-            dq_s = torch.zeros_like(q)
-            dk_s = torch.zeros_like(all_k[i])
-            dv_s = torch.zeros_like(all_v[i])
-            _flash_attn_backward(
-                dout,
+            dq_s, dk_s, dv_s = _flash_attn_bwd(
                 q,
                 all_k[i],
                 all_v[i],
                 combined_out,
+                dout,
                 combined_lse,
-                dq_s,
-                dk_s,
-                dv_s,
-                0.0,
-                ctx.softmax_scale,
-                kv_rank == cp_rank,
-                -1,
-                -1,
-                0.0,
-                None,
-                False,
-                None,
+                softmax_scale=ctx.softmax_scale,
+                causal=(kv_rank == cp_rank),
             )
             dq += dq_s
             if kv_rank == cp_rank:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     "deep-gemm",
-    "flash-attn",
+    "flash-attn-4>=4.0.0b5",
     "tilelang",
     "torch>=2.10.0",
     "transformers",
@@ -41,17 +41,8 @@ deep-gemm = [
     "setuptools",
     "wheel",
 ]
-flash-attn = [
-    { requirement = "torch", match-runtime = true },
-    "ninja",
-    "packaging",
-    "psutil",
-    "wheel",
-]
-
 [tool.uv.extra-build-variables]
 deep-gemm = { DG_FORCE_BUILD = "1", DG_USE_LOCAL_VERSION = "0" }
-flash-attn = { FLASH_ATTENTION_FORCE_BUILD = "TRUE", FLASH_ATTN_CUDA_ARCHS = "90;100" }
 
 [tool.mypy]
 follow_imports = "skip"

--- a/tests/test_ring_attention.py
+++ b/tests/test_ring_attention.py
@@ -13,8 +13,8 @@ import sys
 
 import torch
 import torch.distributed as dist
-from flash_attn import flash_attn_func
 
+from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
 
 


### PR DESCRIPTION
## Summary of Changes

- Migrate all `flash-attn` (v2) usage to `flash-attn-4` (CuTeDSL)
- Add `pithtrain/operators/flash_attn_v4.py` — a `torch.library.custom_op` wrapper around FA4's internals, enabling `torch.compile(fullgraph=True)` compatibility (FA4 beta's `autograd.Function` is not directly traceable by dynamo)
- Qwen3 GQA attention now uses FA4 via the custom_op wrapper
- Ring attention (`standard.py`) migrated from FA2's `_flash_attn_forward`/`_flash_attn_backward` to FA4's `_flash_attn_fwd`/`_flash_attn_bwd`
- MLA (DeepSeek) and its context parallel (ring MLA) are unchanged for a future revision

## End-to-End Performance on NVIDIA B200

**Model**: qwen3-30b-a3b; **Device**: 1x8-b200; **Mesh**: 2pp-1dp-1cp-4ep; **Sequence Length**: 4096; **Dtype**: bf16.

Before the change, using GQA with flash-attn-2.8.3,

```shell
2026-03-27 19:24:11 | INFO | step 00000009/00000025 | step-time 41.015 sec | cross-entropy-loss 2.6123 | load-balance-loss 0.001800 | learning-rate 1.000000e-06 | gradient-norm 9.9290 | tokens-per-second 102,261 | peak-gpu-memory 120.20 GB
2026-03-27 19:24:52 | INFO | step 00000010/00000025 | step-time 40.937 sec | cross-entropy-loss 2.5900 | load-balance-loss 0.001830 | learning-rate 1.000000e-06 | gradient-norm 8.7906 | tokens-per-second 102,457 | peak-gpu-memory 119.92 GB
2026-03-27 19:25:33 | INFO | step 00000011/00000025 | step-time 40.960 sec | cross-entropy-loss 2.5658 | load-balance-loss 0.001810 | learning-rate 1.000000e-06 | gradient-norm 8.6957 | tokens-per-second 102,401 | peak-gpu-memory 120.06 GB
2026-03-27 19:26:15 | INFO | step 00000012/00000025 | step-time 41.112 sec | cross-entropy-loss 2.5901 | load-balance-loss 0.001819 | learning-rate 1.000000e-06 | gradient-norm 8.5794 | tokens-per-second 102,023 | peak-gpu-memory 119.99 GB
```

After the change, using flash-attn-4,

```shell
2026-03-28 01:44:05 | INFO | step 00000009/00000025 | step-time 35.555 sec | cross-entropy-loss 2.6123 | load-balance-loss 0.001800 | learning-rate 1.000000e-06 | gradient-norm 9.9299 | tokens-per-second 117,966 | peak-gpu-memory 120.18 GB
2026-03-28 01:44:41 | INFO | step 00000010/00000025 | step-time 35.310 sec | cross-entropy-loss 2.5900 | load-balance-loss 0.001830 | learning-rate 1.000000e-06 | gradient-norm 8.7873 | tokens-per-second 118,786 | peak-gpu-memory 119.92 GB
2026-03-28 01:45:16 | INFO | step 00000011/00000025 | step-time 35.491 sec | cross-entropy-loss 2.5659 | load-balance-loss 0.001810 | learning-rate 1.000000e-06 | gradient-norm 8.6933 | tokens-per-second 118,181 | peak-gpu-memory 120.05 GB
2026-03-28 01:45:52 | INFO | step 00000012/00000025 | step-time 35.389 sec | cross-entropy-loss 2.5901 | load-balance-loss 0.001819 | learning-rate 1.000000e-06 | gradient-norm 8.5872 | tokens-per-second 118,519 | peak-gpu-memory 119.99 GB
```

We see about 16K+ tokens/second throughput improvement under this setting.

## Kernel Performance on NVIDIA B200

### GQA: flash-attn-4 4.0.0b5 vs flash-attn 2.8.3 (h_q=32, h_kv=4, d=128)

#### Forward

| Seq Len | FA4 4.0.0b5 (ms) | FA4 TFLOPS | FA2 2.8.3 (ms) | FA2 TFLOPS | FA4 speedup |
|---------|-------------------|------------|----------------|------------|-------------|
| 2048    | 0.039             | 875.58     | 0.146          | 235.94     | **3.7x**    |
| 4096    | 0.117             | 1176.24    | 0.439          | 313.18     | **3.8x**    |
| 8192    | 0.433             | 1268.84    | 1.483          | 370.69     | **3.4x**    |
| 16384   | 1.692             | 1299.52    | 5.427          | 405.23     | **3.2x**    |
| 32768   | 6.602             | 1332.28    | 20.696         | 425.01     | **3.1x**    |

#### Backward

| Seq Len | FA4 4.0.0b5 (ms) | FA4 TFLOPS | FA2 2.8.3 (ms) | FA2 TFLOPS | FA4 speedup |
|---------|-------------------|------------|----------------|------------|-------------|
| 2048    | 0.159             | 539.18     | 0.406          | 211.67     | **2.6x**    |
| 4096    | 0.409             | 839.48     | 1.257          | 273.38     | **3.1x**    |
| 8192    | 1.341             | 1024.78    | 4.318          | 318.27     | **3.2x**    |
| 16384   | 4.705             | 1168.48    | 15.966         | 344.33     | **3.4x**    |
| 32768   | 18.069            | 1217.02    | 61.460         | 357.80     | **3.4x**    |
