### PR TITLE
Remove unused attention_mask from entire call stack

### DIFF
--- a/pithtrain/dualpipe/execution.py
+++ b/pithtrain/dualpipe/execution.py
@@ -62,7 +62,6 @@ def stage1_f(
     ctx: ExecutionCtx,
     layer: DecoderLayerProtocol,
     hidden_states: torch.Tensor,
-    attention_mask: torch.Tensor,
     position_ids: torch.Tensor,
 ):
     """
@@ -75,7 +74,7 @@ def stage1_f(
     next_hidden_states = hidden_states.detach().requires_grad_()
     record.args = Stage1Args(prev_hidden_states, next_hidden_states)
 
-    output = layer.forward_attn(next_hidden_states, attention_mask, position_ids)
+    output = layer.forward_attn(next_hidden_states, position_ids)
     ctx.comp_stream.record_event(ctx.fwd_event)
 
     if hasattr(layer.mlp, "experts"):
@@ -457,7 +456,6 @@ def stage5_and_stage1_f(
     topk_weight: torch.Tensor,
     hidden_states: torch.Tensor,
     residual: torch.Tensor,
-    attention_mask: torch.Tensor,
     position_ids: torch.Tensor,
 ):
     """
@@ -479,7 +477,7 @@ def stage5_and_stage1_f(
         moe_outs, moe_local_idxs, topk_weight, hidden_states, residual
     )
 
-    output = next_layer.forward_attn(hidden_states, attention_mask, position_ids)
+    output = next_layer.forward_attn(hidden_states, position_ids)
     ctx.comp_stream.record_event(ctx.fwd_event)
 
     if hasattr(next_layer.mlp, "experts"):

--- a/pithtrain/dualpipe/modeling.py
+++ b/pithtrain/dualpipe/modeling.py
@@ -78,7 +78,6 @@ def decoder_layer_forward_combine(
 def decoder_layer_forward(
     layer: DecoderLayerProtocol,
     hidden_states: torch.Tensor,
-    attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
 ):
     """
@@ -87,7 +86,7 @@ def decoder_layer_forward(
 
     if ModelImplMode.use_reference_fwd:
         return (
-            layer.reference_forward(hidden_states, attention_mask, position_ids),
+            layer.reference_forward(hidden_states, position_ids),
             [],
         )
 
@@ -100,7 +99,7 @@ def decoder_layer_forward(
     next_hidden_states = hidden_states.detach().requires_grad_()
     record.args = Stage1Args(prev_hidden_states, next_hidden_states)
 
-    output = layer.forward_attn(next_hidden_states, attention_mask, position_ids)
+    output = layer.forward_attn(next_hidden_states, position_ids)
     (
         hidden_states,
         sorted_tokens,

--- a/pithtrain/dualpipe/overlap.py
+++ b/pithtrain/dualpipe/overlap.py
@@ -88,8 +88,7 @@ def overlapped_forward_backward(
     module1_layers = [layer for _, layer in module1.layers.items()]
 
     (hidden_states,) = inputs0
-    attention_mask = const_inputs0[0]
-    position_ids = const_inputs0[1] if len(const_inputs0) > 1 else None
+    position_ids = const_inputs0[0] if len(const_inputs0) > 0 else None
     # intermediate_tensors0 is pre-allocated and passed in
     layer_idx0 = 0  # Index into intermediate_tensors0.layers
 
@@ -137,7 +136,7 @@ def overlapped_forward_backward(
         intermediate_tensors0.prolog.args = record.args
         intermediate_tensors0.prolog.outs = record.outs
 
-    record, output = stage1_f(ctx, module0_layers[0], hidden_states, attention_mask, position_ids)
+    record, output = stage1_f(ctx, module0_layers[0], hidden_states, position_ids)
     intermediate_tensors0.layers[layer_idx0].stage1.args = record.args
     intermediate_tensors0.layers[layer_idx0].stage1.outs = record.outs
     (
@@ -253,7 +252,6 @@ def overlapped_forward_backward(
                     topk_weight,
                     hidden_states,
                     residual,
-                    attention_mask,
                     position_ids,
                 )
                 # Store stage5.args at prev layer (no outs -> merged indicator)
@@ -291,9 +289,7 @@ def overlapped_forward_backward(
                 intermediate_tensors0.layers[layer_idx0].stage5.outs = record.outs
                 layer_idx0 += 1
                 # Module 0 layer l stage 1 forward
-                record, output = stage1_f(
-                    ctx, module0_layers[l], hidden_states, attention_mask, position_ids
-                )
+                record, output = stage1_f(ctx, module0_layers[l], hidden_states, position_ids)
                 intermediate_tensors0.layers[layer_idx0].stage1.args = record.args
                 intermediate_tensors0.layers[layer_idx0].stage1.outs = record.outs
                 (
@@ -383,7 +379,7 @@ def overlapped_forward_backward(
     if len(module0.layers) == len(module1.layers) + 1:
         # There is an extra layer in module0 for forward
         hidden_states, extra_layer = decoder_layer_forward(
-            module0_layers[-1], hidden_states, attention_mask, position_ids
+            module0_layers[-1], hidden_states, position_ids
         )
         # Copy into pre-allocated slot
         _copy_layer_records(extra_layer, intermediate_tensors0.layers[layer_idx0])

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -420,7 +420,6 @@ class DeepseekV2LiteAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         bsz, q_len, _ = hidden_states.size()
@@ -507,7 +506,6 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
     def _forward_attn_compute(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor],
         position_ids: Optional[torch.LongTensor],
     ):
         residual = hidden_states
@@ -515,7 +513,6 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
         # Self Attention
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
-            attention_mask=attention_mask,
             position_ids=position_ids,
         )
         hidden_states = residual + hidden_states
@@ -528,13 +525,10 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
     def forward_attn(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ):
         """LN + Attn + LN + Expert selection"""
-        hidden_states, residual = self._forward_attn_compute(
-            hidden_states, attention_mask, position_ids
-        )
+        hidden_states, residual = self._forward_attn_compute(hidden_states, position_ids)
 
         assert isinstance(self.mlp, (DeepseekV2LiteMLP, DeepseekV2LiteMoEWithGroupGeMM))
         if isinstance(self.mlp, DeepseekV2LiteMLP):
@@ -648,7 +642,6 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
     def reference_forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ):
         residual = hidden_states
@@ -659,7 +652,6 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
         try:
             hidden_states = self.self_attn(
                 hidden_states=hidden_states,
-                attention_mask=attention_mask,
                 position_ids=position_ids,
             )
         finally:
@@ -726,7 +718,6 @@ class DeepseekV2LiteModel(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ):
         # Get pre-allocated intermediate_tensors from module attribute (set by DualPipeV)
@@ -745,7 +736,7 @@ class DeepseekV2LiteModel(nn.Module):
                     offset, offset + seq_len, device=hidden_states.device
                 ).unsqueeze(0)
             for _, layer in self.layers.items():
-                ret = decoder_layer_forward(layer, hidden_states, attention_mask, position_ids)
+                ret = decoder_layer_forward(layer, hidden_states, position_ids)
                 hidden_states = ret[0] if isinstance(ret, tuple) else ret
             if self.norm is not None:
                 hidden_states = self.norm(hidden_states)
@@ -767,7 +758,7 @@ class DeepseekV2LiteModel(nn.Module):
             ).unsqueeze(0)
 
         for _, layer in self.layers.items():
-            ret = decoder_layer_forward(layer, hidden_states, attention_mask, position_ids)
+            ret = decoder_layer_forward(layer, hidden_states, position_ids)
             if len(ret) == 2:
                 hidden_states, layer_record = ret
                 # Copy into pre-allocated slot

--- a/pithtrain/models/interface.py
+++ b/pithtrain/models/interface.py
@@ -44,7 +44,6 @@ class DecoderLayerProtocol(Protocol):
     def reference_forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         """
@@ -54,7 +53,6 @@ class DecoderLayerProtocol(Protocol):
     def forward_attn(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> ForwardAttnOutput:
         """

--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -385,7 +385,6 @@ class Qwen3MoeAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Forward pass for GQA attention.
@@ -396,8 +395,6 @@ class Qwen3MoeAttention(nn.Module):
             Input tensor of shape [batch, seq_len, hidden_size].
         position_embeddings : Tuple[torch.Tensor, torch.Tensor]
             Tuple of (cos, sin) for rotary embeddings.
-        attention_mask : Optional[torch.Tensor]
-            Attention mask (unused with Flash Attention causal mode).
 
         Returns
         -------
@@ -519,7 +516,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
     def _forward_attn_compute(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor],
         position_ids: Optional[torch.LongTensor],
     ):
         residual = hidden_states
@@ -532,7 +528,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
-            attention_mask=attention_mask,
         )
         hidden_states = residual + hidden_states
 
@@ -544,13 +539,10 @@ class Qwen3MoeDecoderLayer(nn.Module):
     def forward_attn(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> ForwardAttnOutput:
         """LN + Attn + LN + Expert selection."""
-        hidden_states, residual = self._forward_attn_compute(
-            hidden_states, attention_mask, position_ids
-        )
+        hidden_states, residual = self._forward_attn_compute(hidden_states, position_ids)
 
         if isinstance(self.mlp, Qwen3MoeMLP):
             return ForwardAttnOutput(
@@ -658,7 +650,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
     def reference_forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         """
@@ -677,7 +668,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
             hidden_states = self.self_attn(
                 hidden_states=hidden_states,
                 position_embeddings=position_embeddings,
-                attention_mask=attention_mask,
             )
         finally:
             self.self_attn._disable_ring_attn = False
@@ -783,7 +773,6 @@ class Qwen3MoeModel(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         """
@@ -794,8 +783,6 @@ class Qwen3MoeModel(nn.Module):
         hidden_states : torch.Tensor
             Input tensor. If stage_id == 0, this should be input_ids.
             Otherwise, it should be hidden states from the previous stage.
-        attention_mask : Optional[torch.Tensor]
-            Attention mask.
         position_ids : Optional[torch.LongTensor]
             Position indices.
 
@@ -829,7 +816,7 @@ class Qwen3MoeModel(nn.Module):
             if self.embed_tokens is not None:
                 pass
             for _, layer in self.layers.items():
-                ret = decoder_layer_forward(layer, hidden_states, attention_mask, position_ids)
+                ret = decoder_layer_forward(layer, hidden_states, position_ids)
                 hidden_states = ret[0] if isinstance(ret, tuple) else ret
             if self.norm is not None:
                 hidden_states = self.norm(hidden_states)
@@ -842,7 +829,7 @@ class Qwen3MoeModel(nn.Module):
             intermediate_tensors.prolog.outs = PrologOuts(hidden_states)
 
         for _, layer in self.layers.items():
-            ret = decoder_layer_forward(layer, hidden_states, attention_mask, position_ids)
+            ret = decoder_layer_forward(layer, hidden_states, position_ids)
             if len(ret) == 2:
                 hidden_states, layer_record = ret
                 dst = intermediate_tensors.layers[layer_idx]

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -15,7 +15,6 @@ import torch
 import torch.distributed.fsdp
 import torch.nn as nn
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-from torch.nn.attention.flex_attention import create_block_mask
 from torch.optim import Adam, Optimizer
 from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 from transformers import AutoConfig
@@ -331,14 +330,9 @@ def setup_model(cfg: TrainingCfg, ctx: TrainingCtx, distributed: DistributedCtx)
     modules = nn.Sequential(*modules)
     apply_fsdp(modules, device_mesh)
 
-    def causal(b, h, q_idx, kv_idx):
-        return q_idx >= kv_idx
-
     local_seq_len = cfg.sequence_length // cp_size
     # sequence_length = cfg.sequence_length, TODO this is kept here for stripe context parallelism
     micro_batch_size = cfg.micro_batch_size
-    B, H, Q_LEN, KV_LEN = None, None, local_seq_len, local_seq_len
-    attention_mask = create_block_mask(causal, B, H, Q_LEN, KV_LEN)
 
     # Propagate MoE load balance loss to gate modules.
     if cfg.moe_load_balance_coef > 0:
@@ -360,9 +354,7 @@ def setup_model(cfg: TrainingCfg, ctx: TrainingCtx, distributed: DistributedCtx)
                     if cp_group is not None:
                         gate.compute = gate.compute.__wrapped__.__get__(gate, type(gate))
 
-    ctx.model = DualPipeV(
-        modules, const_inputs=(attention_mask,), pp_group=pp_group, ep_group=ep_group
-    )
+    ctx.model = DualPipeV(modules, const_inputs=(), pp_group=pp_group, ep_group=ep_group)
     set_p2p_tensor_shapes([(micro_batch_size, local_seq_len, hidden_size)])
     set_p2p_tensor_dtype(torch.bfloat16)
 

--- a/tests/test_deepseek_backward_compat.py
+++ b/tests/test_deepseek_backward_compat.py
@@ -18,7 +18,6 @@ from types import SimpleNamespace
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.attention.flex_attention import create_block_mask
 from transformers import AutoConfig
 
 from pithtrain.dualpipe import DualPipeV, set_p2p_tensor_dtype, set_p2p_tensor_shapes
@@ -105,14 +104,7 @@ def main():
 
         apply_fsdp(modules, ctx.device_mesh)
 
-        def causal(b, h, q_idx, kv_idx):
-            return q_idx >= kv_idx
-
-        attention_mask = create_block_mask(causal, B=None, H=None, Q_LEN=S, KV_LEN=S)
-
-        model = DualPipeV(
-            modules, const_inputs=(attention_mask,), pp_group=pp_group, ep_group=ep_group
-        )
+        model = DualPipeV(modules, const_inputs=(), pp_group=pp_group, ep_group=ep_group)
         set_p2p_tensor_shapes([(B, S, hidden_size)])
         set_p2p_tensor_dtype(dtype)
 

--- a/tests/test_fsdp.py
+++ b/tests/test_fsdp.py
@@ -13,7 +13,6 @@ import torch.distributed.fsdp
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-from torch.nn.attention.flex_attention import create_block_mask
 from transformers import AutoConfig
 
 from pithtrain.dualpipe import DualPipeV, set_p2p_tensor_dtype, set_p2p_tensor_shapes
@@ -55,11 +54,10 @@ def reference_step(
     l: torch.Tensor,  # noqa: E741
     model: Union[DeepseekV2LiteModel, Qwen3MoeModel],
     chunks: int,
-    attention_mask: torch.Tensor,
 ):
     ys, ls = [], []
     for micro_x, micro_l in zip(x.chunk(chunks), l.chunk(chunks)):
-        micro_y = model(micro_x, attention_mask=attention_mask)
+        micro_y = model(micro_x)
         loss = criterion(micro_y, micro_l)
         loss.backward()
         ys.append(micro_y)
@@ -199,13 +197,6 @@ def main(ctx: DistributedCtx, model_name: str):
         ep_rank
     ]
 
-    def causal(b, h, q_idx, kv_idx):
-        return q_idx >= kv_idx
-
-    attention_mask = create_block_mask(
-        causal, B=None, H=None, Q_LEN=sequence_length, KV_LEN=sequence_length
-    )
-
     # Create the reference full model.
     config.ep_size = 1
 
@@ -221,9 +212,7 @@ def main(ctx: DistributedCtx, model_name: str):
     torch.distributed.barrier()
 
     ModelImplMode.use_reference_fwd = True
-    loss_ref, output_ref = reference_step(
-        full_x, full_l, full_modules, num_chunks * ep_size, attention_mask
-    )
+    loss_ref, output_ref = reference_step(full_x, full_l, full_modules, num_chunks * ep_size)
 
     if ctx.rank == 0:
         print("[INFO] Completed the reference step.", flush=True)
@@ -279,7 +268,7 @@ def main(ctx: DistributedCtx, model_name: str):
     kwargs = dict()
     kwargs["pp_group"] = pp_group
     kwargs["ep_group"] = ep_group
-    kwargs["const_inputs"] = (attention_mask,)
+    kwargs["const_inputs"] = ()
     dualpipev_model = DualPipeV(local_modules, **kwargs)
 
     # Run the DualPipeV step.


### PR DESCRIPTION
1. flash-attn-4 for GQA in Qwen3
2. TileLang/Triton for MLA in DeepSeek-V2-Lite

Neither of the attention kernels in this codebase require the "materialized" attention mask. However, we do create it and pass down the entire call stack, which is unnecessary. Training does gets launched properly after this removal.

```
2026-03-29 20:02:21 | INFO | launch(cfg=PretrainLanguageModelCfg(distributed=DistributedCfg(pipeline_parallel_size=2, context_parallel_size=1, expert_parallel_size=2), training=TrainingCfg(dataset=PosixPath('workspace/pithtrain/datasets/dclm-baseline/toktxt/deepseek-v2'), sequence_length=4096, seed=1234, min_lr=1e-06, max_lr=1e-06, warmup_steps=0, max_steps=25, micro_batch_size=1, global_batch_size=1024, optimizer='Adam', scheduler='Constant', model=PosixPath('Pith-Train/examples/pretrain_language_model/deepseek-v2-lite/config.json'), save_interval=25, save_location=PosixPath('workspace/pithtrain/checkpoints/deepseek-v2-lite'), moe_load_balance_coef=0.003, moe_load_balance_type='sequence', fp8_training='disabled', init_std=0.02, nsys_start=None, nsys_stop=None), logging=LoggingCfg(wandb=None)))
2026-03-29 20:02:31 | INFO | Load checkpoint: workspace/pithtrain/checkpoints/deepseek-v2-lite/torch-dcp/step-00000000
2026-03-29 20:02:37 | INFO | Load checkpoint: Elapsed min=5.9s, max=5.9s
2026-03-29 20:05:34 | INFO | step 00000001/00000025 | step-time 177.036 sec | cross-entropy-loss 2.5317 | load-balance-loss 0.003228 | learning-rate 1.000000e-06 | gradient-norm 6.1188 | tokens-per-second 23,692 | peak-gpu-memory 95.47 GB
2026-03-29 20:06:17 | INFO | step 00000002/00000025 | step-time 43.126 sec | cross-entropy-loss 2.5194 | load-balance-loss 0.003223 | learning-rate 1.000000e-06 | gradient-norm 6.1281 | tokens-per-second 97,256 | peak-gpu-memory 95.43 GB
2026-03-29 20:07:01 | INFO | step 00000003/00000025 | step-time 43.226 sec | cross-entropy-loss 2.5041 | load-balance-loss 0.003225 | learning-rate 1.000000e-06 | gradient-norm 5.9667 | tokens-per-second 97,032 | peak-gpu-memory 95.50 GB
```