### PR TITLE
Reduce MoE aggregate activation memory via multiply + scatter_add.

### DIFF
--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -613,17 +613,21 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
         def moe_finalize(moe_outs, moe_local_idxs, topk_weight) -> torch.Tensor:
             if self.mlp.ep_size > 1:
                 assert moe_local_idxs is not None
-                new_x = torch.empty_like(moe_outs)
-                new_x[moe_local_idxs] = moe_outs
+                seq_len, topk = topk_weight.shape
+                # Memory-efficient equivalent of
+                # new_x[moe_local_idxs] = moe_outs followed by weighted sum.
+                permuted_probs = topk_weight.view(-1)[moe_local_idxs]
+                token_indices = moe_local_idxs // topk
+                weighted = (moe_outs.float() * permuted_probs.unsqueeze(-1)).to(moe_outs.dtype)
+                result = moe_outs.new_zeros(seq_len, moe_outs.shape[-1])
+                result.scatter_add_(0, token_indices[:, None].expand_as(weighted), weighted)
+                return result
             else:
                 assert moe_local_idxs is None
                 new_x = moe_outs
-            final_out = (
-                (new_x.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(dim=-1))
-                .sum(dim=1)
-                .to(new_x.dtype)
-            )
-            return final_out
+                final_out = new_x.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(dim=-1)
+                final_out = final_out.sum(dim=1).to(new_x.dtype)
+                return final_out
 
         if isinstance(self.mlp, DeepseekV2LiteMoEWithGroupGeMM):
             hidden_states = moe_finalize(moe_outs, moe_local_idxs, topk_weight).view(

--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -624,18 +624,21 @@ class Qwen3MoeDecoderLayer(nn.Module):
         if isinstance(self.mlp, Qwen3MoeMoE):
             if self.mlp.ep_size > 1:
                 assert moe_local_idxs is not None
-                new_x = torch.empty_like(moe_outs)
-                new_x[moe_local_idxs] = moe_outs
+                seq_len, topk = topk_weight.shape
+                # Memory-efficient equivalent of
+                # new_x[moe_local_idxs] = moe_outs followed by weighted sum.
+                permuted_probs = topk_weight.view(-1)[moe_local_idxs]
+                token_indices = moe_local_idxs // topk
+                weighted = (moe_outs.float() * permuted_probs.unsqueeze(-1)).to(moe_outs.dtype)
+                hidden_states = moe_outs.new_zeros(seq_len, moe_outs.shape[-1])
+                hidden_states.scatter_add_(0, token_indices[:, None].expand_as(weighted), weighted)
+                hidden_states = hidden_states.view(*moe_input_hidden_states.shape)
             else:
                 assert moe_local_idxs is None
                 new_x = moe_outs
-
-            final_out = (
-                (new_x.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(dim=-1))
-                .sum(dim=1)
-                .to(new_x.dtype)
-            )
-            hidden_states = final_out.view(*residual.shape)
+                final_out = new_x.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(dim=-1)
+                final_out = final_out.sum(dim=1).to(new_x.dtype)
+                hidden_states = final_out.view(*moe_input_hidden_states.shape)
         else:
             assert moe_local_idxs is None
             assert topk_weight is None


### PR DESCRIPTION
Replace the MoE aggregate pattern `empty → index_put → view*weight → sum` with `multiply(permuted_probs) → scatter_add`. `torch.compile` fuses the ops, avoiding saving the large `[seq*topk, H]` intermediate in autograd.

<div align="center">

| Model | Config | Throughput | Peak Memory |
|---|---|---|---|
| DeepSeek-V2-Lite | 1x8 H100, 2pp-2dp-1cp-2ep | 86.91K → **85.49K** (-1.6%) | 57.22 → **56.05 GB** (-1.17) |
| Qwen3-30B-A3B | 2x8 H100, 2pp-1dp-1cp-8ep | 72.37K → **76.37K** (+5.5%) | 64.14 → **61.31 GB** (-2.83) |

</div>

## End-to-End Training

### 1

**Model**: deepseek-v2-lite; **Device**: 1x8-h100; **Mesh**: 2pp-2dp-1cp-2ep; **Sequence Length**: 2048; **Dtype**: bf16.

Before the change, the median throughput is 86.91K tokens/second, with peak memory being 57.22 GB.

```shell
2026-03-31 17:37:47 | INFO | step 00000016/00000025 | step-time 24.510 sec | cross-entropy-loss 2.4565 | load-balance-loss 0.003234 | learning-rate 1.000000e-06 | gradient-norm 2.1499 | tokens-per-second 85,564 | peak-gpu-memory 57.22 GB
2026-03-31 17:38:11 | INFO | step 00000017/00000025 | step-time 24.510 sec | cross-entropy-loss 2.4274 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 1.8705 | tokens-per-second 85,565 | peak-gpu-memory 57.19 GB
2026-03-31 17:38:36 | INFO | step 00000018/00000025 | step-time 24.392 sec | cross-entropy-loss 2.4354 | load-balance-loss 0.003229 | learning-rate 1.000000e-06 | gradient-norm 1.4273 | tokens-per-second 85,976 | peak-gpu-memory 57.20 GB
2026-03-31 17:39:01 | INFO | step 00000019/00000025 | step-time 24.288 sec | cross-entropy-loss 2.4143 | load-balance-loss 0.003224 | learning-rate 1.000000e-06 | gradient-norm 1.4044 | tokens-per-second 86,344 | peak-gpu-memory 57.19 GB
2026-03-31 17:39:25 | INFO | step 00000020/00000025 | step-time 23.952 sec | cross-entropy-loss 2.4180 | load-balance-loss 0.003223 | learning-rate 1.000000e-06 | gradient-norm 1.3637 | tokens-per-second 87,556 | peak-gpu-memory 57.20 GB
2026-03-31 17:39:49 | INFO | step 00000021/00000025 | step-time 23.874 sec | cross-entropy-loss 2.4449 | load-balance-loss 0.003224 | learning-rate 1.000000e-06 | gradient-norm 1.3525 | tokens-per-second 87,842 | peak-gpu-memory 57.20 GB
2026-03-31 17:40:13 | INFO | step 00000022/00000025 | step-time 23.834 sec | cross-entropy-loss 2.4286 | load-balance-loss 0.003230 | learning-rate 1.000000e-06 | gradient-norm 1.2894 | tokens-per-second 87,989 | peak-gpu-memory 57.18 GB
2026-03-31 17:40:38 | INFO | step 00000023/00000025 | step-time 24.238 sec | cross-entropy-loss 2.3759 | load-balance-loss 0.003223 | learning-rate 1.000000e-06 | gradient-norm 1.2787 | tokens-per-second 86,522 | peak-gpu-memory 57.18 GB
2026-03-31 17:41:02 | INFO | step 00000024/00000025 | step-time 24.021 sec | cross-entropy-loss 2.4277 | load-balance-loss 0.003230 | learning-rate 1.000000e-06 | gradient-norm 1.3302 | tokens-per-second 87,303 | peak-gpu-memory 57.16 GB
2026-03-31 17:41:26 | INFO | step 00000025/00000025 | step-time 23.983 sec | cross-entropy-loss 2.4257 | load-balance-loss 0.003226 | learning-rate 1.000000e-06 | gradient-norm 1.2105 | tokens-per-second 87,444 | peak-gpu-memory 57.17 GB
```

After the change, the median throughput is 85.49K tokens/second, with peak memory being 56.05 GB.

```shell
2026-03-31 18:22:49 | INFO | step 00000016/00000025 | step-time 24.560 sec | cross-entropy-loss 2.4565 | load-balance-loss 0.003234 | learning-rate 1.000000e-06 | gradient-norm 2.1506 | tokens-per-second 85,390 | peak-gpu-memory 56.05 GB
2026-03-31 18:23:14 | INFO | step 00000017/00000025 | step-time 24.486 sec | cross-entropy-loss 2.4274 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 1.8753 | tokens-per-second 85,648 | peak-gpu-memory 56.01 GB
2026-03-31 18:23:38 | INFO | step 00000018/00000025 | step-time 24.554 sec | cross-entropy-loss 2.4353 | load-balance-loss 0.003229 | learning-rate 1.000000e-06 | gradient-norm 1.4260 | tokens-per-second 85,411 | peak-gpu-memory 56.03 GB
2026-03-31 18:24:03 | INFO | step 00000019/00000025 | step-time 24.550 sec | cross-entropy-loss 2.4145 | load-balance-loss 0.003224 | learning-rate 1.000000e-06 | gradient-norm 1.3918 | tokens-per-second 85,422 | peak-gpu-memory 56.01 GB
2026-03-31 18:24:28 | INFO | step 00000020/00000025 | step-time 24.466 sec | cross-entropy-loss 2.4180 | load-balance-loss 0.003223 | learning-rate 1.000000e-06 | gradient-norm 1.3634 | tokens-per-second 85,719 | peak-gpu-memory 56.00 GB
2026-03-31 18:24:53 | INFO | step 00000021/00000025 | step-time 24.599 sec | cross-entropy-loss 2.4449 | load-balance-loss 0.003224 | learning-rate 1.000000e-06 | gradient-norm 1.3544 | tokens-per-second 85,252 | peak-gpu-memory 56.02 GB
2026-03-31 18:25:18 | INFO | step 00000022/00000025 | step-time 24.545 sec | cross-entropy-loss 2.4286 | load-balance-loss 0.003230 | learning-rate 1.000000e-06 | gradient-norm 1.2900 | tokens-per-second 85,442 | peak-gpu-memory 56.00 GB
2026-03-31 18:25:43 | INFO | step 00000023/00000025 | step-time 24.494 sec | cross-entropy-loss 2.3760 | load-balance-loss 0.003223 | learning-rate 1.000000e-06 | gradient-norm 1.2803 | tokens-per-second 85,621 | peak-gpu-memory 56.03 GB
2026-03-31 18:26:08 | INFO | step 00000024/00000025 | step-time 24.468 sec | cross-entropy-loss 2.4277 | load-balance-loss 0.003230 | learning-rate 1.000000e-06 | gradient-norm 1.3305 | tokens-per-second 85,711 | peak-gpu-memory 55.99 GB
2026-03-31 18:26:32 | INFO | step 00000025/00000025 | step-time 24.508 sec | cross-entropy-loss 2.4256 | load-balance-loss 0.003226 | learning-rate 1.000000e-06 | gradient-norm 1.2109 | tokens-per-second 85,569 | peak-gpu-memory 56.00 GB
```

### 2

**Model**: qwen3-30b-a3b; **Device**: 2x8-h100; **Mesh**: 2pp-1dp-1cp-8ep; **Sequence Length**: 2048; **Dtype**: bf16.

Before the change, the median throughput is 72.37K tokens/second, with peak memory being 64.14 GB.

```shell
2026-03-31 17:52:16 | INFO | step 00000016/00000025 | step-time 29.792 sec | cross-entropy-loss 2.5806 | load-balance-loss 0.001806 | learning-rate 1.000000e-06 | gradient-norm 15.5436 | tokens-per-second 70,394 | peak-gpu-memory 64.13 GB
2026-03-31 17:52:45 | INFO | step 00000017/00000025 | step-time 28.659 sec | cross-entropy-loss 2.5855 | load-balance-loss 0.001800 | learning-rate 1.000000e-06 | gradient-norm 13.6361 | tokens-per-second 73,176 | peak-gpu-memory 64.05 GB
2026-03-31 17:53:14 | INFO | step 00000018/00000025 | step-time 29.104 sec | cross-entropy-loss 2.5808 | load-balance-loss 0.001824 | learning-rate 1.000000e-06 | gradient-norm 11.0405 | tokens-per-second 72,058 | peak-gpu-memory 64.31 GB
2026-03-31 17:53:44 | INFO | step 00000019/00000025 | step-time 29.375 sec | cross-entropy-loss 2.4304 | load-balance-loss 0.001810 | learning-rate 1.000000e-06 | gradient-norm 10.5696 | tokens-per-second 71,393 | peak-gpu-memory 64.09 GB
2026-03-31 17:54:14 | INFO | step 00000020/00000025 | step-time 29.405 sec | cross-entropy-loss 2.4546 | load-balance-loss 0.001801 | learning-rate 1.000000e-06 | gradient-norm 10.4716 | tokens-per-second 71,320 | peak-gpu-memory 64.12 GB
2026-03-31 17:54:42 | INFO | step 00000021/00000025 | step-time 28.294 sec | cross-entropy-loss 2.5453 | load-balance-loss 0.001827 | learning-rate 1.000000e-06 | gradient-norm 10.1094 | tokens-per-second 74,121 | peak-gpu-memory 64.11 GB
2026-03-31 17:55:13 | INFO | step 00000022/00000025 | step-time 30.113 sec | cross-entropy-loss 2.5678 | load-balance-loss 0.001851 | learning-rate 1.000000e-06 | gradient-norm 9.8542 | tokens-per-second 69,643 | peak-gpu-memory 64.14 GB
2026-03-31 17:55:42 | INFO | step 00000023/00000025 | step-time 28.820 sec | cross-entropy-loss 2.5323 | load-balance-loss 0.001846 | learning-rate 1.000000e-06 | gradient-norm 9.7647 | tokens-per-second 72,768 | peak-gpu-memory 64.16 GB
2026-03-31 17:56:11 | INFO | step 00000024/00000025 | step-time 28.864 sec | cross-entropy-loss 2.5443 | load-balance-loss 0.001808 | learning-rate 1.000000e-06 | gradient-norm 9.5848 | tokens-per-second 72,656 | peak-gpu-memory 64.11 GB
2026-03-31 17:56:40 | INFO | step 00000025/00000025 | step-time 28.580 sec | cross-entropy-loss 2.5430 | load-balance-loss 0.001856 | learning-rate 1.000000e-06 | gradient-norm 8.9013 | tokens-per-second 73,378 | peak-gpu-memory 64.07 GB
```

After the change, the median throughput is 76.37K tokens/second, with peak memory being 61.31 GB.

```shell
2026-03-31 18:08:40 | INFO | step 00000016/00000025 | step-time 27.942 sec | cross-entropy-loss 2.5803 | load-balance-loss 0.001806 | learning-rate 1.000000e-06 | gradient-norm 15.5398 | tokens-per-second 75,055 | peak-gpu-memory 61.11 GB
2026-03-31 18:09:08 | INFO | step 00000017/00000025 | step-time 27.412 sec | cross-entropy-loss 2.5855 | load-balance-loss 0.001800 | learning-rate 1.000000e-06 | gradient-norm 13.6545 | tokens-per-second 76,505 | peak-gpu-memory 61.05 GB
2026-03-31 18:09:36 | INFO | step 00000018/00000025 | step-time 27.824 sec | cross-entropy-loss 2.5807 | load-balance-loss 0.001824 | learning-rate 1.000000e-06 | gradient-norm 11.0367 | tokens-per-second 75,372 | peak-gpu-memory 61.31 GB
2026-03-31 18:10:04 | INFO | step 00000019/00000025 | step-time 27.529 sec | cross-entropy-loss 2.4303 | load-balance-loss 0.001810 | learning-rate 1.000000e-06 | gradient-norm 10.5834 | tokens-per-second 76,180 | peak-gpu-memory 61.10 GB
2026-03-31 18:10:31 | INFO | step 00000020/00000025 | step-time 27.132 sec | cross-entropy-loss 2.4545 | load-balance-loss 0.001801 | learning-rate 1.000000e-06 | gradient-norm 10.4852 | tokens-per-second 77,294 | peak-gpu-memory 61.11 GB
2026-03-31 18:10:59 | INFO | step 00000021/00000025 | step-time 27.517 sec | cross-entropy-loss 2.5455 | load-balance-loss 0.001827 | learning-rate 1.000000e-06 | gradient-norm 10.1165 | tokens-per-second 76,213 | peak-gpu-memory 61.12 GB
2026-03-31 18:11:27 | INFO | step 00000022/00000025 | step-time 27.393 sec | cross-entropy-loss 2.5678 | load-balance-loss 0.001851 | learning-rate 1.000000e-06 | gradient-norm 9.8615 | tokens-per-second 76,559 | peak-gpu-memory 61.17 GB
2026-03-31 18:11:54 | INFO | step 00000023/00000025 | step-time 27.099 sec | cross-entropy-loss 2.5323 | load-balance-loss 0.001846 | learning-rate 1.000000e-06 | gradient-norm 9.7671 | tokens-per-second 77,388 | peak-gpu-memory 61.17 GB
2026-03-31 18:12:22 | INFO | step 00000024/00000025 | step-time 27.281 sec | cross-entropy-loss 2.5441 | load-balance-loss 0.001808 | learning-rate 1.000000e-06 | gradient-norm 9.5993 | tokens-per-second 76,873 | peak-gpu-memory 61.10 GB
2026-03-31 18:12:50 | INFO | step 00000025/00000025 | step-time 27.727 sec | cross-entropy-loss 2.5430 | load-balance-loss 0.001856 | learning-rate 1.000000e-06 | gradient-norm 8.9102 | tokens-per-second 75,637 | peak-gpu-memory 61.08 GB
```