### PR TITLE
Move shared expert computation from Stage 5 to Stage 1.

### DIFF
--- a/pithtrain/dualpipe/execution.py
+++ b/pithtrain/dualpipe/execution.py
@@ -41,7 +41,6 @@ class Stage1Args(NamedTuple):
 
 
 class Stage1OutsMoe(NamedTuple):
-    hidden_states: torch.Tensor
     sorted_tokens: torch.Tensor
     topk_weight: torch.Tensor
     residual: torch.Tensor
@@ -78,9 +77,7 @@ def stage1_f(
     ctx.comp_stream.record_event(ctx.fwd_event)
 
     if hasattr(layer.mlp, "experts"):
-        record.outs = Stage1OutsMoe(
-            output.hidden_states, output.sorted_tokens, output.topk_weight, output.residual
-        )
+        record.outs = Stage1OutsMoe(output.sorted_tokens, output.topk_weight, output.residual)
     else:
         record.outs = Stage1OutsMlp(output.sorted_tokens, output.residual)
 
@@ -372,7 +369,6 @@ def stage4_b(
 class Stage5Args(NamedTuple):
     moe_outs: torch.Tensor
     topk_weight: torch.Tensor
-    hidden_states: torch.Tensor
     residual: torch.Tensor
 
 
@@ -392,7 +388,6 @@ def stage5_f(
     moe_outs: torch.Tensor,
     moe_local_idxs,
     topk_weight: torch.Tensor,
-    hidden_states: torch.Tensor,
     residual: torch.Tensor,
 ):
     """
@@ -403,16 +398,13 @@ def stage5_f(
 
     moe_outs = moe_outs.detach().requires_grad_()
     topk_weight = topk_weight.detach().requires_grad_() if topk_weight is not None else None
-    hidden_states = hidden_states.detach().requires_grad_()
     residual = residual.detach().requires_grad_()
-    record.args = Stage5Args(moe_outs, topk_weight, hidden_states, residual)
+    record.args = Stage5Args(moe_outs, topk_weight, residual)
 
     if ctx.fwd_comm_work is not None:
         ctx.fwd_comm_work.wait()
 
-    hidden_states = layer.forward_aggregate(
-        moe_outs, moe_local_idxs, topk_weight, hidden_states, residual
-    )
+    hidden_states = layer.forward_aggregate(moe_outs, moe_local_idxs, topk_weight, residual)
     record.outs = Stage5Outs(hidden_states)
 
     nvtx.range_pop()
@@ -434,12 +426,12 @@ def stage5_b(
 
     ctx.comp_stream.record_event(ctx.bwd_event)
 
-    moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = [
+    moe_outs_grad, topk_weight_grad, residual_grad = [
         t.grad if t is not None else None for t in record.args
     ]
 
     nvtx.range_pop()
-    return moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad
+    return moe_outs_grad, topk_weight_grad, residual_grad
 
 
 # ------------------------------------------------------------
@@ -454,7 +446,6 @@ def stage5_and_stage1_f(
     moe_outs: torch.Tensor,
     moe_local_idxs,
     topk_weight: torch.Tensor,
-    hidden_states: torch.Tensor,
     residual: torch.Tensor,
     position_ids: torch.Tensor,
 ):
@@ -466,24 +457,21 @@ def stage5_and_stage1_f(
 
     moe_outs = moe_outs.detach().requires_grad_()
     topk_weight = topk_weight.detach().requires_grad_() if topk_weight is not None else None
-    hidden_states = hidden_states.detach().requires_grad_()
     residual = residual.detach().requires_grad_()
-    stage5_args = Stage5Args(moe_outs, topk_weight, hidden_states, residual)
+    stage5_args = Stage5Args(moe_outs, topk_weight, residual)
 
     if ctx.fwd_comm_work is not None:
         ctx.fwd_comm_work.wait()
 
     hidden_states = prev_layer.forward_aggregate(
-        moe_outs, moe_local_idxs, topk_weight, hidden_states, residual
+        moe_outs, moe_local_idxs, topk_weight, residual
     )
 
     output = next_layer.forward_attn(hidden_states, position_ids)
     ctx.comp_stream.record_event(ctx.fwd_event)
 
     if hasattr(next_layer.mlp, "experts"):
-        stage1_outs = Stage1OutsMoe(
-            output.hidden_states, output.sorted_tokens, output.topk_weight, output.residual
-        )
+        stage1_outs = Stage1OutsMoe(output.sorted_tokens, output.topk_weight, output.residual)
     else:
         stage1_outs = Stage1OutsMlp(output.sorted_tokens, output.residual)
 
@@ -512,12 +500,12 @@ def stage5_and_stage1_b(
 
     ctx.comp_stream.record_event(ctx.bwd_event)
 
-    moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = [
+    moe_outs_grad, topk_weight_grad, residual_grad = [
         t.grad if t is not None else None for t in stage5_args
     ]
 
     nvtx.range_pop()
-    return moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad
+    return moe_outs_grad, topk_weight_grad, residual_grad
 
 
 # ------------------------------------------------------------

--- a/pithtrain/dualpipe/modeling.py
+++ b/pithtrain/dualpipe/modeling.py
@@ -101,7 +101,6 @@ def decoder_layer_forward(
 
     output = layer.forward_attn(next_hidden_states, position_ids)
     (
-        hidden_states,
         sorted_tokens,
         moe_local_idxs,
         topk_weight,
@@ -118,9 +117,7 @@ def decoder_layer_forward(
     ep_group = layer.mlp.ep_group if has_experts else None
 
     if has_experts:
-        record.outs = Stage1OutsMoe(
-            output.hidden_states, output.sorted_tokens, output.topk_weight, output.residual
-        )
+        record.outs = Stage1OutsMoe(output.sorted_tokens, output.topk_weight, output.residual)
     else:
         record.outs = Stage1OutsMlp(output.sorted_tokens, output.residual)
     intermediate_tensors.stage1 = record
@@ -178,14 +175,13 @@ def decoder_layer_forward(
     record = Stage5Record()
     moe_outs = moe_outs.detach().requires_grad_()
     topk_weight = topk_weight.detach().requires_grad_() if topk_weight is not None else None
-    hidden_states = hidden_states.detach().requires_grad_()
     residual = residual.detach().requires_grad_()
-    record.args = Stage5Args(moe_outs, topk_weight, hidden_states, residual)
+    record.args = Stage5Args(moe_outs, topk_weight, residual)
 
     if fwd_comm_work is not None:
         fwd_comm_work.wait()
     hidden_states = layer.forward_aggregate(
-        moe_outs, moe_local_idxs, topk_weight, hidden_states, residual
+        moe_outs, moe_local_idxs, topk_weight, residual
     )
 
     record.outs = Stage5Outs(hidden_states)
@@ -236,30 +232,19 @@ def decoder_layer_backward(
         loss.backward()
         loss.detach_()
     elif stage5_was_merged:
-        # Stage5 was merged with next layer's stage1. Get grads from stage5.args.
-        # These were computed when the next layer ran its merged stage1 backward.
         nvtx.range_push("layer%02d.stage5_merged_skip" % layer.idx)
-        moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = [
+        moe_outs_grad, topk_weight_grad, residual_grad = [
             t.grad if t is not None else None for t in stage5_record.args
         ]
         nvtx.range_pop()
     else:
-        # Normal case: run stage5 backward
         nvtx.range_push("layer%02d.stage5_b" % layer.idx)
         record = stage5_record
         run_backward(record.outs, dy)
-        moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = [
+        moe_outs_grad, topk_weight_grad, residual_grad = [
             t.grad if t is not None else None for t in record.args
         ]
         nvtx.range_pop()
-
-    # Some models do not have shared experts, so the original hidden states weren't used
-    # during the forward pass of stage 5. As a result, its gradients will be None. For
-    # compatibility with the pipeline, we manually set its gradient to zero here.
-    if hidden_states_grad is None:
-        outs = stage1_record.outs
-        data = outs.hidden_states if isinstance(outs, Stage1OutsMoe) else outs.sorted_tokens
-        hidden_states_grad = torch.zeros_like(data)
 
     # Stage 4.
     nvtx.range_push("layer%02d.stage4_b" % layer.idx)
@@ -305,7 +290,7 @@ def decoder_layer_backward(
         bwd_comm_work.wait()
 
     if hasattr(layer.mlp, "experts"):
-        grad_tensors = (hidden_states_grad, sorted_tokens_grad, topk_weight_grad, residual_grad)
+        grad_tensors = (sorted_tokens_grad, topk_weight_grad, residual_grad)
     else:
         grad_tensors = (sorted_tokens_grad, residual_grad)
 

--- a/pithtrain/dualpipe/overlap.py
+++ b/pithtrain/dualpipe/overlap.py
@@ -17,7 +17,6 @@ from pithtrain.dualpipe.execution import (
     ExecutionCtx,
     IntermediateTensors,
     IntermediateTensorsLayer,
-    Stage1OutsMoe,
     epilog_f,
     prolog_b,
     prolog_f,
@@ -114,17 +113,9 @@ def overlapped_forward_backward(
     assert output_grads1 is not None
 
     record = intermediate_tensors1.layers[-1].stage5
-    moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = stage5_b(
+    moe_outs_grad, topk_weight_grad, residual_grad = stage5_b(
         ctx, module1_layers[-1], record, tuple(output_grads1)
     )
-
-    # Some models do not have shared experts, so the original hidden states weren't used
-    # during the forward pass of stage 5. As a result, its gradients will be None. For
-    # compatibility with the pipeline, we manually set its gradient to zero here.
-    if hidden_states_grad is None:
-        outs = intermediate_tensors1.layers[-1].stage1.outs
-        data = outs.hidden_states if isinstance(outs, Stage1OutsMoe) else outs.sorted_tokens
-        hidden_states_grad = torch.zeros_like(data)
 
     # Module 1 layer L-1 stage 4 backward
     record = intermediate_tensors1.layers[-1].stage4
@@ -140,7 +131,6 @@ def overlapped_forward_backward(
     intermediate_tensors0.layers[layer_idx0].stage1.args = record.args
     intermediate_tensors0.layers[layer_idx0].stage1.outs = record.outs
     (
-        hidden_states,
         sorted_tokens,
         moe_local_idxs,
         topk_weight,
@@ -167,21 +157,18 @@ def overlapped_forward_backward(
             )
 
             if use_merged:
-                # Merge the stage 5 and stage 1 backward into a single stage.
-                # stage1.outs is at layer -l, stage5.args is at layer -l-1
                 next_layer, prev_layer = module1_layers[-l], module1_layers[-l - 1]
                 stage1_outs = stage1_record.outs
                 stage5_args = intermediate_tensors1.layers[-l - 1].stage5.args
                 if hasattr(next_layer.mlp, "experts"):
                     grad_tensors = (
-                        hidden_states_grad,
                         sorted_tokens_grad,  # noqa: F821
                         topk_weight_grad,
                         residual_grad,
                     )
                 else:
                     grad_tensors = (sorted_tokens_grad, residual_grad)  # noqa: F821
-                moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = (
+                moe_outs_grad, topk_weight_grad, residual_grad = (
                     stage5_and_stage1_b(
                         ctx, next_layer, prev_layer, stage1_outs, stage5_args, grad_tensors
                     )
@@ -193,7 +180,6 @@ def overlapped_forward_backward(
                 record = intermediate_tensors1.layers[-l].stage1
                 if hasattr(module1_layers[-l].mlp, "experts"):
                     grad_tensors = (
-                        hidden_states_grad,
                         sorted_tokens_grad,  # noqa: F821
                         topk_weight_grad,
                         residual_grad,
@@ -203,19 +189,11 @@ def overlapped_forward_backward(
                 hidden_states_grad = stage1_b(ctx, module1_layers[-l], record, grad_tensors)
                 # Module 1 layer L-l-1 stage 5 backward
                 record = intermediate_tensors1.layers[-l - 1].stage5
-                moe_outs_grad, topk_weight_grad, hidden_states_grad, residual_grad = stage5_b(
+                moe_outs_grad, topk_weight_grad, residual_grad = stage5_b(
                     ctx, module1_layers[-l - 1], record, (hidden_states_grad,)
                 )
                 # Clear tensor refs but keep pre-allocated records
                 _clear_layer_records(intermediate_tensors1.layers[-l])
-
-            # Some models do not have shared experts, so the original hidden states weren't used
-            # during the forward pass of stage 5. As a result, its gradients will be None. For
-            # compatibility with the pipeline, we manually set its gradient to zero here.
-            if hidden_states_grad is None:
-                outs = intermediate_tensors1.layers[-l - 1].stage1.outs
-                data = outs.hidden_states if isinstance(outs, Stage1OutsMoe) else outs.sorted_tokens
-                hidden_states_grad = torch.zeros_like(data)
 
             # Module 0 layer l-1 stage 4 forward
             record, moe_outs = stage4_f(
@@ -250,7 +228,6 @@ def overlapped_forward_backward(
                     moe_outs,
                     moe_local_idxs,
                     topk_weight,
-                    hidden_states,
                     residual,
                     position_ids,
                 )
@@ -262,7 +239,6 @@ def overlapped_forward_backward(
                 # stage1.args stays None
                 intermediate_tensors0.layers[layer_idx0].stage1.outs = stage1_outs
                 (
-                    hidden_states,
                     sorted_tokens,
                     moe_local_idxs,
                     topk_weight,
@@ -282,7 +258,6 @@ def overlapped_forward_backward(
                     moe_outs,
                     moe_local_idxs,
                     topk_weight,
-                    hidden_states,
                     residual,
                 )
                 intermediate_tensors0.layers[layer_idx0].stage5.args = record.args
@@ -293,7 +268,6 @@ def overlapped_forward_backward(
                 intermediate_tensors0.layers[layer_idx0].stage1.args = record.args
                 intermediate_tensors0.layers[layer_idx0].stage1.outs = record.outs
                 (
-                    hidden_states,
                     sorted_tokens,
                     moe_local_idxs,
                     topk_weight,
@@ -353,7 +327,7 @@ def overlapped_forward_backward(
     record = intermediate_tensors1.layers[-num_layers].stage1
 
     if hasattr(module1_layers[-num_layers].mlp, "experts"):
-        grad_tensors = (hidden_states_grad, sorted_tokens_grad, topk_weight_grad, residual_grad)
+        grad_tensors = (sorted_tokens_grad, topk_weight_grad, residual_grad)
     else:
         grad_tensors = (sorted_tokens_grad, residual_grad)
 
@@ -369,7 +343,6 @@ def overlapped_forward_backward(
         moe_outs,
         moe_local_idxs,
         topk_weight,
-        hidden_states,
         residual,
     )
     intermediate_tensors0.layers[layer_idx0].stage5.args = record.args

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -520,6 +520,9 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
 
+        if hasattr(self.mlp, "shared_experts"):
+            residual = residual + self.mlp.shared_experts(hidden_states)
+
         return hidden_states, residual
 
     def forward_attn(
@@ -532,9 +535,7 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
 
         assert isinstance(self.mlp, (DeepseekV2LiteMLP, DeepseekV2LiteMoEWithGroupGeMM))
         if isinstance(self.mlp, DeepseekV2LiteMLP):
-            # The MLP is not MoE, so we don't need to do expert selection
             return ForwardAttnOutput(
-                hidden_states,
                 hidden_states,  # sorted_tokens
                 None,  # idxs
                 None,  # topk_weight
@@ -563,7 +564,6 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
             self.mlp.ep_group,
         )
         return ForwardAttnOutput(
-            hidden_states,
             sorted_tokens,
             idxs,
             topk_weight,
@@ -603,10 +603,12 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
         moe_outs: torch.Tensor,
         moe_local_idxs: Optional[torch.Tensor],
         topk_weight: Optional[torch.Tensor],
-        moe_input_hidden_states: torch.Tensor,
         residual: torch.Tensor,
     ):
-        """Computation after all-to-all combine"""
+        """
+        Weighted expert output + residual connection.
+        Shared expert output is already folded into residual by forward_attn.
+        """
 
         def moe_finalize(moe_outs, moe_local_idxs, topk_weight) -> torch.Tensor:
             if self.mlp.ep_size > 1:
@@ -624,13 +626,9 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
             return final_out
 
         if isinstance(self.mlp, DeepseekV2LiteMoEWithGroupGeMM):
-            moe_y = moe_finalize(moe_outs, moe_local_idxs, topk_weight).view(
-                *moe_input_hidden_states.shape
+            hidden_states = moe_finalize(moe_outs, moe_local_idxs, topk_weight).view(
+                *residual.shape
             )
-            if self.mlp.config.n_shared_experts is not None:
-                moe_y = moe_y + self.mlp.shared_experts(moe_input_hidden_states)
-
-            hidden_states = moe_y
         else:
             assert moe_local_idxs is None
             assert topk_weight is None

--- a/pithtrain/models/interface.py
+++ b/pithtrain/models/interface.py
@@ -9,7 +9,6 @@ class ForwardAttnOutput(NamedTuple):
     Output from the forward_attn method of a decoder layer.
     """
 
-    hidden_states: torch.Tensor
     sorted_tokens: torch.Tensor
     moe_local_idxs: torch.Tensor
     topk_weight: torch.Tensor
@@ -74,7 +73,6 @@ class DecoderLayerProtocol(Protocol):
         moe_outs: torch.Tensor,
         moe_local_idxs: Optional[torch.Tensor],
         topk_weight: Optional[torch.Tensor],
-        moe_input_hidden_states: torch.Tensor,
         residual: torch.Tensor,
     ) -> torch.Tensor:
         """

--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -546,8 +546,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
 
         if isinstance(self.mlp, Qwen3MoeMLP):
             return ForwardAttnOutput(
-                hidden_states,
-                hidden_states,
+                hidden_states,  # sorted_tokens
                 None,
                 None,
                 None,
@@ -576,7 +575,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
         )
 
         return ForwardAttnOutput(
-            hidden_states,
             sorted_tokens,
             idxs,
             topk_weight,
@@ -618,7 +616,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
         moe_outs: torch.Tensor,
         moe_local_idxs: Optional[torch.Tensor],
         topk_weight: Optional[torch.Tensor],
-        moe_input_hidden_states: torch.Tensor,
         residual: torch.Tensor,
     ) -> torch.Tensor:
         """
@@ -638,7 +635,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
                 .sum(dim=1)
                 .to(new_x.dtype)
             )
-            hidden_states = final_out.view(*moe_input_hidden_states.shape)
+            hidden_states = final_out.view(*residual.shape)
         else:
             assert moe_local_idxs is None
             assert topk_weight is None


### PR DESCRIPTION
- Before the change, there was a 116 µs gap between stage5_stage1_b and stage4_f, which corresponds to 1) hidden states grad zeros_like allocation when shared experts aren't used and 2) clearing the layer records.
- By moving shared expert computation from stage 5 to stage 1, this removes hidden_states pass through and zeros_like allocation in the middle of the pipeline.
- For models with shared experts we see some improvement with the training throughput; while for models that have shared experts which won't "extra" allocate this hidden states grad, we didn't see regression.

## Nsys Profile

Before the change,

<img width="2169" height="875" alt="image" src="https://github.com/user-attachments/assets/9d8b633c-7832-4c70-9930-bbfc8ebf50d6" />

After the change,

<img width="2169" height="875" alt="image" src="https://github.com/user-attachments/assets/b170a62b-279e-44bd-b54c-8b299cff1d63" />

### End-to-End Performance

Training throughput on qwen3-30b-a3b, 2x8h100, 2pp-1dp-1cp-8ep goes up by 2.6%.

Before the change,

```shell
2026-04-01 14:16:12 | INFO | step 00000001/00000015 | step-time 75.154 sec | cross-entropy-loss 2.6636 | load-balance-loss 0.001807 | learning-rate 1.000000e-06 | gradient-norm 20.2692 | tokens-per-second 27,905 | peak-gpu-memory 64.02 GB
2026-04-01 14:16:42 | INFO | step 00000002/00000015 | step-time 30.238 sec | cross-entropy-loss 2.5952 | load-balance-loss 0.001803 | learning-rate 1.000000e-06 | gradient-norm 20.0925 | tokens-per-second 69,356 | peak-gpu-memory 64.21 GB
2026-04-01 14:17:12 | INFO | step 00000003/00000015 | step-time 29.182 sec | cross-entropy-loss 2.6521 | load-balance-loss 0.001826 | learning-rate 1.000000e-06 | gradient-norm 19.8878 | tokens-per-second 71,865 | peak-gpu-memory 64.23 GB
2026-04-01 14:17:43 | INFO | step 00000004/00000015 | step-time 30.383 sec | cross-entropy-loss 2.6988 | load-balance-loss 0.001824 | learning-rate 1.000000e-06 | gradient-norm 19.7678 | tokens-per-second 69,024 | peak-gpu-memory 64.15 GB
2026-04-01 14:18:12 | INFO | step 00000005/00000015 | step-time 29.170 sec | cross-entropy-loss 2.6154 | load-balance-loss 0.001816 | learning-rate 1.000000e-06 | gradient-norm 19.8241 | tokens-per-second 71,894 | peak-gpu-memory 64.13 GB
2026-04-01 14:18:41 | INFO | step 00000006/00000015 | step-time 28.997 sec | cross-entropy-loss 2.6041 | load-balance-loss 0.001806 | learning-rate 1.000000e-06 | gradient-norm 19.1875 | tokens-per-second 72,323 | peak-gpu-memory 64.25 GB
2026-04-01 14:19:10 | INFO | step 00000007/00000015 | step-time 28.685 sec | cross-entropy-loss 2.6493 | load-balance-loss 0.001808 | learning-rate 1.000000e-06 | gradient-norm 18.9898 | tokens-per-second 73,110 | peak-gpu-memory 64.06 GB
2026-04-01 14:19:40 | INFO | step 00000008/00000015 | step-time 29.706 sec | cross-entropy-loss 2.6644 | load-balance-loss 0.001821 | learning-rate 1.000000e-06 | gradient-norm 18.4947 | tokens-per-second 70,597 | peak-gpu-memory 64.11 GB
2026-04-01 14:20:10 | INFO | step 00000009/00000015 | step-time 28.878 sec | cross-entropy-loss 2.6136 | load-balance-loss 0.001846 | learning-rate 1.000000e-06 | gradient-norm 18.4539 | tokens-per-second 72,621 | peak-gpu-memory 64.16 GB
2026-04-01 14:20:40 | INFO | step 00000010/00000015 | step-time 29.650 sec | cross-entropy-loss 2.6513 | load-balance-loss 0.001818 | learning-rate 1.000000e-06 | gradient-norm 16.7111 | tokens-per-second 70,730 | peak-gpu-memory 64.15 GB
2026-04-01 14:21:08 | INFO | step 00000011/00000015 | step-time 28.618 sec | cross-entropy-loss 2.6324 | load-balance-loss 0.001825 | learning-rate 1.000000e-06 | gradient-norm 16.5847 | tokens-per-second 73,282 | peak-gpu-memory 64.23 GB
2026-04-01 14:21:38 | INFO | step 00000012/00000015 | step-time 28.872 sec | cross-entropy-loss 2.5988 | load-balance-loss 0.001802 | learning-rate 1.000000e-06 | gradient-norm 16.2589 | tokens-per-second 72,636 | peak-gpu-memory 64.19 GB
2026-04-01 14:22:06 | INFO | step 00000013/00000015 | step-time 28.445 sec | cross-entropy-loss 2.6135 | load-balance-loss 0.001852 | learning-rate 1.000000e-06 | gradient-norm 16.5112 | tokens-per-second 73,727 | peak-gpu-memory 64.12 GB
2026-04-01 14:22:36 | INFO | step 00000014/00000015 | step-time 29.519 sec | cross-entropy-loss 2.6007 | load-balance-loss 0.001803 | learning-rate 1.000000e-06 | gradient-norm 15.7008 | tokens-per-second 71,045 | peak-gpu-memory 64.08 GB
2026-04-01 14:23:05 | INFO | step 00000015/00000015 | step-time 28.290 sec | cross-entropy-loss 2.6499 | load-balance-loss 0.001827 | learning-rate 1.000000e-06 | gradient-norm 15.7224 | tokens-per-second 74,130 | peak-gpu-memory 64.15 GB
```

After the change,

```shell
2026-04-01 14:06:36 | INFO | step 00000001/00000015 | step-time 73.352 sec | cross-entropy-loss 2.6636 | load-balance-loss 0.001807 | learning-rate 1.000000e-06 | gradient-norm 20.2657 | tokens-per-second 28,590 | peak-gpu-memory 63.65 GB
2026-04-01 14:07:05 | INFO | step 00000002/00000015 | step-time 28.823 sec | cross-entropy-loss 2.5949 | load-balance-loss 0.001803 | learning-rate 1.000000e-06 | gradient-norm 20.0672 | tokens-per-second 72,759 | peak-gpu-memory 63.84 GB
2026-04-01 14:07:33 | INFO | step 00000003/00000015 | step-time 27.786 sec | cross-entropy-loss 2.6520 | load-balance-loss 0.001826 | learning-rate 1.000000e-06 | gradient-norm 19.9174 | tokens-per-second 75,474 | peak-gpu-memory 63.85 GB
2026-04-01 14:08:02 | INFO | step 00000004/00000015 | step-time 28.437 sec | cross-entropy-loss 2.6988 | load-balance-loss 0.001824 | learning-rate 1.000000e-06 | gradient-norm 19.7415 | tokens-per-second 73,748 | peak-gpu-memory 63.77 GB
2026-04-01 14:08:30 | INFO | step 00000005/00000015 | step-time 27.775 sec | cross-entropy-loss 2.6154 | load-balance-loss 0.001816 | learning-rate 1.000000e-06 | gradient-norm 19.8322 | tokens-per-second 75,504 | peak-gpu-memory 63.76 GB
2026-04-01 14:08:59 | INFO | step 00000006/00000015 | step-time 28.702 sec | cross-entropy-loss 2.6041 | load-balance-loss 0.001806 | learning-rate 1.000000e-06 | gradient-norm 19.1916 | tokens-per-second 73,067 | peak-gpu-memory 63.88 GB
2026-04-01 14:09:28 | INFO | step 00000007/00000015 | step-time 28.220 sec | cross-entropy-loss 2.6492 | load-balance-loss 0.001808 | learning-rate 1.000000e-06 | gradient-norm 18.9978 | tokens-per-second 74,314 | peak-gpu-memory 63.69 GB
2026-04-01 14:09:56 | INFO | step 00000008/00000015 | step-time 28.157 sec | cross-entropy-loss 2.6642 | load-balance-loss 0.001821 | learning-rate 1.000000e-06 | gradient-norm 18.4803 | tokens-per-second 74,482 | peak-gpu-memory 63.76 GB
2026-04-01 14:10:24 | INFO | step 00000009/00000015 | step-time 27.601 sec | cross-entropy-loss 2.6134 | load-balance-loss 0.001846 | learning-rate 1.000000e-06 | gradient-norm 18.4564 | tokens-per-second 75,980 | peak-gpu-memory 63.80 GB
2026-04-01 14:10:52 | INFO | step 00000010/00000015 | step-time 28.132 sec | cross-entropy-loss 2.6511 | load-balance-loss 0.001818 | learning-rate 1.000000e-06 | gradient-norm 16.7209 | tokens-per-second 74,546 | peak-gpu-memory 63.77 GB
2026-04-01 14:11:21 | INFO | step 00000011/00000015 | step-time 28.037 sec | cross-entropy-loss 2.6321 | load-balance-loss 0.001825 | learning-rate 1.000000e-06 | gradient-norm 16.5718 | tokens-per-second 74,799 | peak-gpu-memory 63.86 GB
2026-04-01 14:11:50 | INFO | step 00000012/00000015 | step-time 28.905 sec | cross-entropy-loss 2.5988 | load-balance-loss 0.001802 | learning-rate 1.000000e-06 | gradient-norm 16.2743 | tokens-per-second 72,554 | peak-gpu-memory 63.81 GB
2026-04-01 14:12:18 | INFO | step 00000013/00000015 | step-time 28.134 sec | cross-entropy-loss 2.6134 | load-balance-loss 0.001852 | learning-rate 1.000000e-06 | gradient-norm 16.5000 | tokens-per-second 74,540 | peak-gpu-memory 63.74 GB
2026-04-01 14:12:47 | INFO | step 00000014/00000015 | step-time 28.494 sec | cross-entropy-loss 2.6008 | load-balance-loss 0.001803 | learning-rate 1.000000e-06 | gradient-norm 15.7087 | tokens-per-second 73,600 | peak-gpu-memory 63.71 GB
2026-04-01 14:13:15 | INFO | step 00000015/00000015 | step-time 27.774 sec | cross-entropy-loss 2.6495 | load-balance-loss 0.001827 | learning-rate 1.000000e-06 | gradient-norm 15.7098 | tokens-per-second 75,507 | peak-gpu-memory 63.79 GB
```

Training throughput on deepseek-v2-lite, 1x8h100, 2pp-2dp-1cp-2ep remains identical.

Before the change,

```shell
2026-04-01 14:27:31 | INFO | step 00000001/00000015 | step-time 43.142 sec | cross-entropy-loss 2.4934 | load-balance-loss 0.003254 | learning-rate 1.000000e-06 | gradient-norm 3.2699 | tokens-per-second 48,611 | peak-gpu-memory 57.26 GB
2026-04-01 14:27:55 | INFO | step 00000002/00000015 | step-time 24.192 sec | cross-entropy-loss 2.4543 | load-balance-loss 0.003247 | learning-rate 1.000000e-06 | gradient-norm 3.3118 | tokens-per-second 86,689 | peak-gpu-memory 57.21 GB
2026-04-01 14:28:20 | INFO | step 00000003/00000015 | step-time 24.153 sec | cross-entropy-loss 2.4768 | load-balance-loss 0.003253 | learning-rate 1.000000e-06 | gradient-norm 3.2728 | tokens-per-second 86,827 | peak-gpu-memory 57.23 GB
2026-04-01 14:28:44 | INFO | step 00000004/00000015 | step-time 24.184 sec | cross-entropy-loss 2.4414 | load-balance-loss 0.003247 | learning-rate 1.000000e-06 | gradient-norm 3.1711 | tokens-per-second 86,716 | peak-gpu-memory 57.19 GB
2026-04-01 14:29:09 | INFO | step 00000005/00000015 | step-time 24.131 sec | cross-entropy-loss 2.4810 | load-balance-loss 0.003256 | learning-rate 1.000000e-06 | gradient-norm 3.1925 | tokens-per-second 86,907 | peak-gpu-memory 57.22 GB
2026-04-01 14:29:33 | INFO | step 00000006/00000015 | step-time 24.146 sec | cross-entropy-loss 2.4990 | load-balance-loss 0.003250 | learning-rate 1.000000e-06 | gradient-norm 3.0182 | tokens-per-second 86,852 | peak-gpu-memory 57.22 GB
2026-04-01 14:29:58 | INFO | step 00000007/00000015 | step-time 24.119 sec | cross-entropy-loss 2.4586 | load-balance-loss 0.003250 | learning-rate 1.000000e-06 | gradient-norm 2.9523 | tokens-per-second 86,950 | peak-gpu-memory 57.20 GB
2026-04-01 14:30:22 | INFO | step 00000008/00000015 | step-time 24.165 sec | cross-entropy-loss 2.4585 | load-balance-loss 0.003252 | learning-rate 1.000000e-06 | gradient-norm 2.9162 | tokens-per-second 86,786 | peak-gpu-memory 57.19 GB
2026-04-01 14:30:47 | INFO | step 00000009/00000015 | step-time 24.095 sec | cross-entropy-loss 2.4848 | load-balance-loss 0.003244 | learning-rate 1.000000e-06 | gradient-norm 2.8376 | tokens-per-second 87,038 | peak-gpu-memory 57.20 GB
2026-04-01 14:31:11 | INFO | step 00000010/00000015 | step-time 24.141 sec | cross-entropy-loss 2.4732 | load-balance-loss 0.003246 | learning-rate 1.000000e-06 | gradient-norm 2.4039 | tokens-per-second 86,869 | peak-gpu-memory 57.20 GB
2026-04-01 14:31:36 | INFO | step 00000011/00000015 | step-time 24.163 sec | cross-entropy-loss 2.4704 | load-balance-loss 0.003244 | learning-rate 1.000000e-06 | gradient-norm 2.4114 | tokens-per-second 86,791 | peak-gpu-memory 57.22 GB
2026-04-01 14:32:00 | INFO | step 00000012/00000015 | step-time 24.214 sec | cross-entropy-loss 2.4339 | load-balance-loss 0.003245 | learning-rate 1.000000e-06 | gradient-norm 2.3514 | tokens-per-second 86,610 | peak-gpu-memory 57.19 GB
2026-04-01 14:32:25 | INFO | step 00000013/00000015 | step-time 24.178 sec | cross-entropy-loss 2.4043 | load-balance-loss 0.003236 | learning-rate 1.000000e-06 | gradient-norm 2.3280 | tokens-per-second 86,737 | peak-gpu-memory 57.23 GB
2026-04-01 14:32:49 | INFO | step 00000014/00000015 | step-time 24.139 sec | cross-entropy-loss 2.4583 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 2.2452 | tokens-per-second 86,880 | peak-gpu-memory 57.19 GB
2026-04-01 14:33:13 | INFO | step 00000015/00000015 | step-time 24.131 sec | cross-entropy-loss 2.4088 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 2.2076 | tokens-per-second 86,908 | peak-gpu-memory 57.18 GB
```

After the change,

```shell
2026-04-01 14:36:34 | INFO | step 00000001/00000015 | step-time 43.983 sec | cross-entropy-loss 2.4933 | load-balance-loss 0.003254 | learning-rate 1.000000e-06 | gradient-norm 3.2645 | tokens-per-second 47,681 | peak-gpu-memory 57.43 GB
2026-04-01 14:36:59 | INFO | step 00000002/00000015 | step-time 24.185 sec | cross-entropy-loss 2.4542 | load-balance-loss 0.003247 | learning-rate 1.000000e-06 | gradient-norm 3.3099 | tokens-per-second 86,713 | peak-gpu-memory 57.37 GB
2026-04-01 14:37:23 | INFO | step 00000003/00000015 | step-time 24.259 sec | cross-entropy-loss 2.4766 | load-balance-loss 0.003253 | learning-rate 1.000000e-06 | gradient-norm 3.2759 | tokens-per-second 86,447 | peak-gpu-memory 57.40 GB
2026-04-01 14:37:48 | INFO | step 00000004/00000015 | step-time 24.198 sec | cross-entropy-loss 2.4413 | load-balance-loss 0.003247 | learning-rate 1.000000e-06 | gradient-norm 3.1702 | tokens-per-second 86,667 | peak-gpu-memory 57.38 GB
2026-04-01 14:38:12 | INFO | step 00000005/00000015 | step-time 24.112 sec | cross-entropy-loss 2.4809 | load-balance-loss 0.003256 | learning-rate 1.000000e-06 | gradient-norm 3.1882 | tokens-per-second 86,975 | peak-gpu-memory 57.38 GB
2026-04-01 14:38:37 | INFO | step 00000006/00000015 | step-time 24.293 sec | cross-entropy-loss 2.4990 | load-balance-loss 0.003250 | learning-rate 1.000000e-06 | gradient-norm 3.0174 | tokens-per-second 86,326 | peak-gpu-memory 57.40 GB
2026-04-01 14:39:01 | INFO | step 00000007/00000015 | step-time 24.187 sec | cross-entropy-loss 2.4586 | load-balance-loss 0.003250 | learning-rate 1.000000e-06 | gradient-norm 2.9525 | tokens-per-second 86,705 | peak-gpu-memory 57.37 GB
2026-04-01 14:39:26 | INFO | step 00000008/00000015 | step-time 24.218 sec | cross-entropy-loss 2.4583 | load-balance-loss 0.003252 | learning-rate 1.000000e-06 | gradient-norm 2.9137 | tokens-per-second 86,595 | peak-gpu-memory 57.37 GB
2026-04-01 14:39:50 | INFO | step 00000009/00000015 | step-time 24.201 sec | cross-entropy-loss 2.4850 | load-balance-loss 0.003244 | learning-rate 1.000000e-06 | gradient-norm 2.8360 | tokens-per-second 86,654 | peak-gpu-memory 57.36 GB
2026-04-01 14:40:15 | INFO | step 00000010/00000015 | step-time 23.990 sec | cross-entropy-loss 2.4731 | load-balance-loss 0.003246 | learning-rate 1.000000e-06 | gradient-norm 2.4054 | tokens-per-second 87,419 | peak-gpu-memory 57.35 GB
2026-04-01 14:40:39 | INFO | step 00000011/00000015 | step-time 24.091 sec | cross-entropy-loss 2.4703 | load-balance-loss 0.003244 | learning-rate 1.000000e-06 | gradient-norm 2.4154 | tokens-per-second 87,052 | peak-gpu-memory 57.36 GB
2026-04-01 14:41:03 | INFO | step 00000012/00000015 | step-time 24.065 sec | cross-entropy-loss 2.4337 | load-balance-loss 0.003245 | learning-rate 1.000000e-06 | gradient-norm 2.3518 | tokens-per-second 87,145 | peak-gpu-memory 57.35 GB
2026-04-01 14:41:28 | INFO | step 00000013/00000015 | step-time 24.150 sec | cross-entropy-loss 2.4041 | load-balance-loss 0.003236 | learning-rate 1.000000e-06 | gradient-norm 2.3338 | tokens-per-second 86,840 | peak-gpu-memory 57.37 GB
2026-04-01 14:41:52 | INFO | step 00000014/00000015 | step-time 24.339 sec | cross-entropy-loss 2.4581 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 2.2430 | tokens-per-second 86,166 | peak-gpu-memory 57.34 GB
2026-04-01 14:42:17 | INFO | step 00000015/00000015 | step-time 24.260 sec | cross-entropy-loss 2.4086 | load-balance-loss 0.003240 | learning-rate 1.000000e-06 | gradient-norm 2.2091 | tokens-per-second 86,446 | peak-gpu-memory 57.36 GB
```