### PR TITLE
Bump the flash-attn-4 version ; Add the cu13 extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     "deep-gemm",
-    "flash-attn-4>=4.0.0b5",
+    "flash-attn-4[cu13]>=4.0.0b7",
     "tilelang",
     "torch>=2.10.0",
     "transformers",


### PR DESCRIPTION
Our framework requires cu13.0. The official flash-attn-4 pypi page mentions having cu13 extra for the best performance. Additionally, we ping the flash-attn-4 to its latest beta release `4.0.0b7`.