### PR TITLE
Add support for PyTorch memory profiler

### DIFF
--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -158,6 +158,32 @@ class TrainingCfg(SlottedDefault):
     `nsys_stop=N+1`. Set to ``None`` to disable.
     """
 
+    memory_profile_start: Optional[int] = None
+    """
+    Training step at which to start recording CUDA memory allocation history.
+
+    When set, ``torch.cuda.memory._record_memory_history`` is called at the
+    beginning of this step with full stack traces for both allocations and frees.
+    Set to ``None`` to disable.
+    """
+
+    memory_profile_stop: Optional[int] = None
+    """
+    Training step at which to stop recording and dump the memory snapshot.
+
+    At the beginning of this step the recorded history is dumped to
+    ``memory_profile_output`` and recording is disabled. To profile a single
+    step ``N``, set ``memory_profile_start=N`` and ``memory_profile_stop=N+1``.
+    Set to ``None`` to disable.
+    """
+
+    memory_profile_output: Path = Path.cwd()
+    """
+    Output directory for the CUDA memory snapshot. Each rank writes a pickle
+    file named ``snapshot-rank00000.pickle`` etc. into this directory.
+    The snapshot can be visualized at https://pytorch.org/memory_viz.
+    """
+
 
 @dataclass(init=False, slots=True)
 class TrainingCtx:

--- a/pithtrain/tasks/pretrain_language_model.py
+++ b/pithtrain/tasks/pretrain_language_model.py
@@ -353,10 +353,13 @@ def train_step(cfg: PretrainLanguageModelCfg, ctx: PretrainLanguageModelCtx) -> 
     """
     Execute one step of training.
     """
-    if cfg.training.nsys_start is not None and ctx.training.step == cfg.training.nsys_start:
+    # Start the nsys and the memory profiler.
+    start = cfg.training.nsys_start
+    if start is not None and ctx.training.step == start:
         torch.cuda.cudart().cudaProfilerStart()
-    if cfg.training.nsys_stop is not None and ctx.training.step == cfg.training.nsys_stop:
-        torch.cuda.cudart().cudaProfilerStop()
+    start = cfg.training.memory_profile_start
+    if start is not None and ctx.training.step == start:
+        torch.cuda.memory._record_memory_history(max_entries=65536, stacks="python")
 
     device = torch.cuda.current_device()
     t0 = time.time()
@@ -469,6 +472,18 @@ def train_step(cfg: PretrainLanguageModelCfg, ctx: PretrainLanguageModelCtx) -> 
 
     # Increment the step counter.
     ctx.training.step += 1
+
+    # Stop the nsys and the memory profiler.
+    stop = cfg.training.nsys_stop
+    if stop is not None and ctx.training.step == stop:
+        torch.cuda.cudart().cudaProfilerStop()
+    stop = cfg.training.memory_profile_stop
+    if stop is not None and ctx.training.step == stop:
+        rank = ctx.distributed.rank
+        cfg.training.memory_profile_output.mkdir(parents=True, exist_ok=True)
+        path = Path(cfg.training.memory_profile_output, "snapshot-rank%05d.pickle" % rank)
+        torch.cuda.memory._dump_snapshot(str(path))
+        torch.cuda.memory._record_memory_history(enabled=None)
 
     # We should save the checkpoint if any of the following conditions is true:
     # 1. The current step is a multiple of save_interval.


### PR DESCRIPTION
- Add `memory_profile_start`, `memory_profile_stop`, and `memory_profile_output` to `TrainingCfg` for recording CUDA memory allocation history with Python stack traces via `torch.cuda.memory._record_memory_history`. Each rank dumps a per-rank pickle snapshot to `memory_profile_output`, viewable at https://pytorch.org/memory_viz.
- Move nsys and memory profiler stop hooks to after the step counter increment, so profiling a single step (`start=N`, `stop=N+1`) with `max_steps=N+1` dumps immediately instead of silently skipping.
