### PR TITLE
Reduce MoE activation memory in DualPipeV

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -52,3 +52,32 @@ adapted from the original DualPipe project:
 
 A copy of the original MIT license is also retained at:
   pithtrain/dualpipe/LICENSE
+
+================================================================================
+
+NVIDIA TransformerEngine - Apache License 2.0
+
+Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The following code is adapted from NVIDIA TransformerEngine
+(https://github.com/NVIDIA/TransformerEngine):
+
+  pithtrain/operators/cross_entropy.py
+    - The fused cross-entropy Triton kernel and autograd wrapper are
+      adapted from transformer_engine/common/triton/cross_entropy.py
+      and transformer_engine/pytorch/triton/cross_entropy.py. The
+      online-softmax and cross-entropy passes are fused into a single
+      kernel; tensor-parallelism, label-smoothing, and distributed
+      support are removed.

--- a/pithtrain/dualpipe/dualpipev.py
+++ b/pithtrain/dualpipe/dualpipev.py
@@ -31,10 +31,7 @@ import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule, fully_shard
 
 from pithtrain.dualpipe import comm
-from pithtrain.dualpipe.execution import (
-    IntermediateTensors,
-    create_intermediate_tensors,
-)
+from pithtrain.dualpipe.execution import IntermediateTensors, create_intermediate_tensors
 from pithtrain.dualpipe.overlap import overlapped_forward_backward
 from pithtrain.dualpipe.utils import FP8WeightCacheControl, WeightGradStore, gather, scatter
 

--- a/pithtrain/dualpipe/execution.py
+++ b/pithtrain/dualpipe/execution.py
@@ -22,12 +22,27 @@ from pithtrain.operators.all_to_all import direct_all_to_all
 
 @dataclass(init=False, slots=True)
 class ExecutionCtx:
+    """Shared context for the overlapped forward-backward execution loop."""
+
     comp_stream: torch.cuda.Stream
+    """Main compute stream for forward/backward kernels."""
     comm_stream: torch.cuda.Stream
+    """Separate stream for asynchronous all-to-all communication."""
     fwd_event: torch.cuda.Event
+    """Event recorded after forward compute; comm_stream waits on it before dispatch."""
     bwd_event: torch.cuda.Event
+    """Event recorded after backward compute; comm_stream waits on it before combine."""
     fwd_comm_work: Optional[torch.distributed.Work]
+    """Async work handle for the in-flight forward all-to-all (dispatch or combine)."""
     bwd_comm_work: Optional[torch.distributed.Work]
+    """Async work handle for the in-flight backward all-to-all."""
+    fwd_comm_deferred_free: List[torch.Tensor]
+    """Tensors whose storage should be freed after the next fwd_comm_work.wait().
+
+    Callers append tensors here after launching async forward comms (e.g.
+    all-to-all in Stage 2 / Stage 4).  The subsequent stage that waits on
+    fwd_comm_work drains and frees this list automatically.
+    """
 
 
 # ------------------------------------------------------------
@@ -112,18 +127,8 @@ def stage1_b(
 # ------------------------------------------------------------
 
 
-class Stage2Args(NamedTuple):
-    sorted_tokens: torch.Tensor
-
-
-class Stage2Outs(NamedTuple):
-    gathered_tokens: torch.Tensor
-
-
 @dataclass(init=False, slots=True)
 class Stage2Record:
-    args: Stage2Args
-    outs: Stage2Outs
     ctx: Optional[tuple]
 
 
@@ -136,16 +141,14 @@ def stage2_f(
     ep_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
     """
-    Stage2 forward.
+    Stage2 forward: all-to-all dispatch for expert parallelism.
     """
     nvtx.range_push("layer%02d.stage2_f" % layer.idx)
     record = Stage2Record()
 
-    sorted_tokens = sorted_tokens.detach().requires_grad_()
-    record.args = Stage2Args(sorted_tokens)
-
     ctx.comm_stream.wait_event(ctx.fwd_event)
 
+    sorted_tokens = sorted_tokens.detach()
     if output_splits is not None:
         with torch.cuda.stream(ctx.comm_stream):
             gathered_tokens = direct_all_to_all(
@@ -155,7 +158,6 @@ def stage2_f(
     else:
         gathered_tokens = sorted_tokens
         record.ctx = None
-    record.outs = Stage2Outs(gathered_tokens)
 
     ctx.fwd_comm_work = getattr(gathered_tokens, "comm_work", None)
     setattr(gathered_tokens, "comm_work", None)
@@ -168,10 +170,10 @@ def stage2_b(
     ctx: ExecutionCtx,
     layer: DecoderLayerProtocol,
     record: Stage2Record,
-    grad_tensors: Stage2Outs,
+    grad_tensors: tuple,
 ):
     """
-    Stage2 backward.
+    Stage2 backward: reverse all-to-all.
     """
     nvtx.range_push("layer%02d.stage2_b" % layer.idx)
 
@@ -212,6 +214,13 @@ class Stage3Record:
     outs: Stage3Outs
 
 
+def _drain_deferred_free(ctx: ExecutionCtx) -> None:
+    """Free tensor storage that was deferred until after the comm wait."""
+    for t in ctx.fwd_comm_deferred_free:
+        t.untyped_storage().resize_(0)
+    ctx.fwd_comm_deferred_free.clear()
+
+
 def stage3_f(
     ctx: ExecutionCtx,
     layer: DecoderLayerProtocol,
@@ -230,9 +239,15 @@ def stage3_f(
 
     if ctx.fwd_comm_work is not None:
         ctx.fwd_comm_work.wait()
+    _drain_deferred_free(ctx)
 
     moe_outs = layer.forward_mlp(gathered_tokens, expert_idxs, expand_idx)
     record.outs = Stage3Outs(moe_outs)
+    # Free the args storage — only safe for MoE layers with EP where
+    # padded_index_gather is the first consumer and doesn't save the input.
+    # When ep_size==1, gathered_tokens shares storage with sorted_tokens.
+    if hasattr(layer.mlp, "experts") and ctx.fwd_comm_work is not None:
+        gathered_tokens.untyped_storage().resize_(0)
 
     ctx.comp_stream.record_event(ctx.fwd_event)
 
@@ -283,18 +298,8 @@ def stage3_w(ctx: ExecutionCtx, layer: DecoderLayerProtocol):
 # ------------------------------------------------------------
 
 
-class Stage4Args(NamedTuple):
-    moe_outs: torch.Tensor
-
-
-class Stage4Outs(NamedTuple):
-    moe_outs: torch.Tensor
-
-
 @dataclass(init=False, slots=True)
 class Stage4Record:
-    args: Stage4Args
-    outs: Stage4Outs
     ctx: Optional[tuple]
 
 
@@ -307,14 +312,12 @@ def stage4_f(
     ep_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
     """
-    Stage4 forward.
+    Stage4 forward: all-to-all combine for expert parallelism.
     """
     nvtx.range_push("layer%02d.stage4_f" % layer.idx)
     record = Stage4Record()
 
-    moe_outs = moe_outs.detach().requires_grad_()
-    record.args = Stage4Args(moe_outs)
-
+    moe_outs = moe_outs.detach()
     ctx.comm_stream.wait_event(ctx.fwd_event)
 
     if output_splits is not None:
@@ -323,8 +326,6 @@ def stage4_f(
         record.ctx = (input_splits, output_splits, ep_group)
     else:
         record.ctx = None
-
-    record.outs = Stage4Outs(moe_outs)
 
     ctx.fwd_comm_work = getattr(moe_outs, "comm_work", None)
     setattr(moe_outs, "comm_work", None)
@@ -337,10 +338,10 @@ def stage4_b(
     ctx: ExecutionCtx,
     layer: DecoderLayerProtocol,
     record: Stage4Record,
-    grad_tensors: Stage4Outs,
+    grad_tensors: tuple,
 ):
     """
-    Stage4 backward.
+    Stage4 backward: reverse all-to-all.
     """
     nvtx.range_push("layer%02d.stage4_b" % layer.idx)
 
@@ -402,6 +403,7 @@ def stage5_f(
 
     if ctx.fwd_comm_work is not None:
         ctx.fwd_comm_work.wait()
+    _drain_deferred_free(ctx)
 
     hidden_states = layer.forward_aggregate(moe_outs, moe_local_idxs, topk_weight, residual)
     record.outs = Stage5Outs(hidden_states)
@@ -460,6 +462,7 @@ def stage5_and_stage1_f(
 
     if ctx.fwd_comm_work is not None:
         ctx.fwd_comm_work.wait()
+    _drain_deferred_free(ctx)
 
     hidden_states = prev_layer.forward_aggregate(moe_outs, moe_local_idxs, topk_weight, residual)
 
@@ -559,19 +562,18 @@ class EpilogArgs(NamedTuple):
     hidden_states: torch.Tensor
 
 
-class EpilogOuts(NamedTuple):
-    logits: torch.Tensor
-
-
 @dataclass(init=False, slots=True)
 class EpilogRecord:
     args: EpilogArgs
-    outs: EpilogOuts
 
 
 def epilog_f(module: ModelProtocol, hidden_states: torch.Tensor):
     """
     Epilog forward: norm + lm_head.
+
+    The backward is handled by ``loss.backward()`` which traverses the autograd
+    graph through norm → lm_head → criterion.  The only thing the caller needs
+    from the record is ``args.hidden_states.grad`` (populated by autograd).
     """
     nvtx.range_push("epilog_f")
     record = EpilogRecord()
@@ -580,23 +582,9 @@ def epilog_f(module: ModelProtocol, hidden_states: torch.Tensor):
     record.args = EpilogArgs(hidden_states)
     hidden_states = module.norm(hidden_states)
     logits = module.lm_head(hidden_states)
-    record.outs = EpilogOuts(logits)
 
     nvtx.range_pop()
     return record, logits
-
-
-def epilog_b(module: ModelProtocol, record: EpilogRecord, grad_tensors: EpilogOuts):
-    """
-    Epilog backward.
-    """
-    nvtx.range_push("epilog_b")
-
-    run_backward(record.outs, grad_tensors)
-    hidden_states_grad = record.args.hidden_states.grad
-
-    nvtx.range_pop()
-    return hidden_states_grad
 
 
 # ------------------------------------------------------------
@@ -627,8 +615,10 @@ def create_intermediate_tensors_layer() -> IntermediateTensorsLayer:
     layer = IntermediateTensorsLayer()
     layer.stage1 = Stage1Record()
     layer.stage2 = Stage2Record()
+    layer.stage2.ctx = None
     layer.stage3 = Stage3Record()
     layer.stage4 = Stage4Record()
+    layer.stage4.ctx = None
     layer.stage5 = Stage5Record()
     return layer
 

--- a/pithtrain/dualpipe/layer_partition.py
+++ b/pithtrain/dualpipe/layer_partition.py
@@ -1,0 +1,82 @@
+"""Layer partitioning for DualPipeV pipeline stages.
+
+In the V-shaped pipeline, stage 0 holds ``embed_tokens`` and stage N-1 holds
+``norm`` + ``lm_head``.  These extra components add parameter, optimizer-state,
+gradient, and activation memory that the middle stages don't carry.  To
+compensate, we give the edge stages fewer decoder layers, shifting the surplus
+to their immediate neighbors.
+"""
+
+from typing import List
+
+from pithtrain.dualpipe.utils import print_msg
+
+
+def layer_partition(num_layers: int, num_stages: int, verbose: bool = True) -> List[int]:
+    """Distribute *num_layers* decoder layers across *num_stages* pipeline stages.
+
+    The algorithm:
+
+    1. Start with an even ``num_layers // num_stages`` per stage.
+    2. Distribute the ``num_layers % num_stages`` remainder layers one at a
+       time to the globally smallest stage, breaking ties in favour of
+       inner stages so that edges stay light when possible.
+
+    Parameters
+    ----------
+    num_layers : int
+        Total number of decoder layers (must be ≥ num_stages).
+    num_stages : int
+        Number of pipeline stages (= 2 × pp_size).
+
+    Returns
+    -------
+    list[int]
+        Number of layers per stage.  ``sum(result) == num_layers``.
+    """
+    assert num_layers >= num_stages >= 1, (
+        f"Need num_layers ({num_layers}) >= num_stages ({num_stages}) >= 1"
+    )
+
+    base, remainder = divmod(num_layers, num_stages)
+    layers = [base] * num_stages
+
+    # ── Distribute remainder ──
+    for _ in range(remainder):
+        min_val = min(layers)
+        best = None
+        # Prefer an inner stage at the minimum value
+        for i in range(1, num_stages - 1):
+            if layers[i] == min_val:
+                best = i
+                break
+        # Fall back to an edge stage
+        if best is None:
+            for i in range(num_stages):
+                if layers[i] == min_val:
+                    best = i
+                    break
+        layers[best] += 1
+
+    assert sum(layers) == num_layers
+
+    # DualPipeV constraint: each pp_rank holds two stages (phase 0 and phase 1)
+    # whose layer counts must differ by at most 1 for the overlapped
+    # forward-backward schedule to work correctly.
+    if num_stages % 2 == 0:
+        pp_size = num_stages // 2
+        for k in range(pp_size):
+            diff = abs(layers[k] - layers[num_stages - 1 - k])
+            assert diff <= 1, (
+                f"DualPipeV requires abs(num_layers_phase0 - num_layers_phase1) <= 1 "
+                f"for each pp_rank, but pp_rank {k} has {layers[k]} vs "
+                f"{layers[num_stages - 1 - k]} layers (diff={diff}). "
+                f"Partition: {layers}"
+            )
+
+    if verbose:
+        print_msg(
+            f"layer_partition: {num_layers} layers / {num_stages} stages → {layers}",
+            rank0_only=True,
+        )
+    return layers

--- a/pithtrain/dualpipe/modeling.py
+++ b/pithtrain/dualpipe/modeling.py
@@ -11,14 +11,10 @@ from pithtrain.dualpipe.execution import (
     Stage1OutsMlp,
     Stage1OutsMoe,
     Stage1Record,
-    Stage2Args,
-    Stage2Outs,
     Stage2Record,
     Stage3Args,
     Stage3Outs,
     Stage3Record,
-    Stage4Args,
-    Stage4Outs,
     Stage4Record,
     Stage5Args,
     Stage5Outs,
@@ -125,16 +121,11 @@ def decoder_layer_forward(
     # Stage 2.
     nvtx.range_push("layer%02d.stage2_f" % layer.idx)
     record = Stage2Record()
-    sorted_tokens = sorted_tokens.detach().requires_grad_()
-    record.args = Stage2Args(sorted_tokens)
-
     gathered_tokens, record.ctx = decoder_layer_forward_dispatch(
-        sorted_tokens, dedup_output_splits, dedup_input_splits, ep_group
+        sorted_tokens.detach(), dedup_output_splits, dedup_input_splits, ep_group
     )
     fwd_comm_work = getattr(gathered_tokens, "comm_work", None)
     setattr(gathered_tokens, "comm_work", None)
-
-    record.outs = Stage2Outs(gathered_tokens)
     intermediate_tensors.stage2 = record
     nvtx.range_pop()
 
@@ -146,26 +137,33 @@ def decoder_layer_forward(
 
     if fwd_comm_work is not None:
         fwd_comm_work.wait()
+    # Stage 2 all-to-all has completed — sorted_tokens storage is no longer read.
+    # Free it now; run_backward only needs the grad_fn chain, not the values.
+    # Guard: only when a2a actually occurred (ep_size > 1); otherwise sorted_tokens
+    # and gathered_tokens share storage.
+    if has_experts and fwd_comm_work is not None:
+        sorted_tokens.untyped_storage().resize_(0)
 
     moe_outs = layer.forward_mlp(gathered_tokens, expert_idxs, expand_idx)
 
     record.outs = Stage3Outs(moe_outs)
+    # Free args storage — values no longer needed, only .grad is read after backward.
+    # Only safe for MoE layers with EP: padded_index_gather is the first consumer and
+    # doesn't save the input.  For dense layers or ep_size==1, gate_proj/up_proj may
+    # save gathered_tokens directly, or it shares storage with sorted_tokens.
+    if has_experts and fwd_comm_work is not None:
+        gathered_tokens.untyped_storage().resize_(0)
     intermediate_tensors.stage3 = record
     nvtx.range_pop()
 
     # Stage 4.
     nvtx.range_push("layer%02d.stage4_f" % layer.idx)
     record = Stage4Record()
-    moe_outs = moe_outs.detach().requires_grad_()
-    record.args = Stage4Args(moe_outs)
-
     moe_outs, record.ctx = decoder_layer_forward_combine(
-        moe_outs, input_splits, output_splits, ep_group
+        moe_outs.detach(), input_splits, output_splits, ep_group
     )
     fwd_comm_work = getattr(moe_outs, "comm_work", None)
     setattr(moe_outs, "comm_work", None)
-
-    record.outs = Stage4Outs(moe_outs)
     intermediate_tensors.stage4 = record
     nvtx.range_pop()
 
@@ -179,6 +177,9 @@ def decoder_layer_forward(
 
     if fwd_comm_work is not None:
         fwd_comm_work.wait()
+    # Stage 4 all-to-all has completed — Stage 3 output is no longer read.
+    if has_experts and fwd_comm_work is not None:
+        intermediate_tensors.stage3.outs.moe_outs.untyped_storage().resize_(0)
     hidden_states = layer.forward_aggregate(moe_outs, moe_local_idxs, topk_weight, residual)
 
     record.outs = Stage5Outs(hidden_states)

--- a/pithtrain/dualpipe/overlap.py
+++ b/pithtrain/dualpipe/overlap.py
@@ -51,13 +51,14 @@ def _clear_layer_records(layer: IntermediateTensorsLayer) -> None:
 def _copy_layer_records(src: IntermediateTensorsLayer, dst: IntermediateTensorsLayer) -> None:
     """
     Copy record fields from src to dst (pre-allocated).
-    Skip records where args wasn't set (record exists but wasn't used).
+    Skip records that have no populated fields.
     """
     for field in fields(src):
         if not hasattr(src, field.name):
             continue
         src_record = getattr(src, field.name)
-        if not hasattr(src_record, "args"):
+        # Skip if the record has no populated fields at all
+        if not any(hasattr(src_record, rf.name) for rf in fields(src_record)):
             continue
         dst_record = getattr(dst, field.name)
         for rf in fields(src_record):
@@ -96,6 +97,7 @@ def overlapped_forward_backward(
     ctx.bwd_event = torch.cuda.Event()
     ctx.fwd_comm_work = None
     ctx.bwd_comm_work = None
+    ctx.fwd_comm_deferred_free = []
 
     # Module 1 layer L-1 stage 5 backward
     if loss1 is not None:
@@ -106,7 +108,6 @@ def overlapped_forward_backward(
         output_grads1 = [intermediate_tensors1.epilog.args.hidden_states.grad]
         # Clear tensor refs but keep pre-allocated record
         intermediate_tensors1.epilog.args = None
-        intermediate_tensors1.epilog.outs = None
         loss1 = None
     assert output_grads1 is not None
 
@@ -200,9 +201,11 @@ def overlapped_forward_backward(
                 output_splits,
                 ep_group,
             )
-            intermediate_tensors0.layers[layer_idx0].stage4.args = record.args
-            intermediate_tensors0.layers[layer_idx0].stage4.outs = record.outs
             intermediate_tensors0.layers[layer_idx0].stage4.ctx = record.ctx
+            if hasattr(module0_layers[l - 1].mlp, "experts") and ctx.fwd_comm_work is not None:
+                ctx.fwd_comm_deferred_free.append(
+                    intermediate_tensors0.layers[layer_idx0].stage3.outs.moe_outs
+                )  # freed after Stage 5 waits
 
             # Module 1 layer L-l-1 stage 4 backward
             record = intermediate_tensors1.layers[-l - 1].stage4
@@ -288,9 +291,9 @@ def overlapped_forward_backward(
             dedup_input_splits,
             ep_group,
         )
-        intermediate_tensors0.layers[layer_idx0].stage2.args = record.args
-        intermediate_tensors0.layers[layer_idx0].stage2.outs = record.outs
         intermediate_tensors0.layers[layer_idx0].stage2.ctx = record.ctx
+        if hasattr(module0_layers[l].mlp, "experts") and ctx.fwd_comm_work is not None:
+            ctx.fwd_comm_deferred_free.append(sorted_tokens)  # freed after Stage 3 waits
 
         # Module 1 layer L-l-1 stage 2 backward
         record = intermediate_tensors1.layers[-l - 1].stage2
@@ -314,9 +317,11 @@ def overlapped_forward_backward(
     record, moe_outs = stage4_f(
         ctx, module0_layers[num_layers - 1], moe_outs, input_splits, output_splits, ep_group
     )
-    intermediate_tensors0.layers[layer_idx0].stage4.args = record.args
-    intermediate_tensors0.layers[layer_idx0].stage4.outs = record.outs
     intermediate_tensors0.layers[layer_idx0].stage4.ctx = record.ctx
+    if hasattr(module0_layers[num_layers - 1].mlp, "experts") and ctx.fwd_comm_work is not None:
+        ctx.fwd_comm_deferred_free.append(
+            intermediate_tensors0.layers[layer_idx0].stage3.outs.moe_outs
+        )  # freed after Stage 5 waits
 
     # Module 1 layer 0 stage 1 backward
     record = intermediate_tensors1.layers[-num_layers].stage1
@@ -372,7 +377,6 @@ def overlapped_forward_backward(
     if module0.norm is not None:
         record, hidden_states = epilog_f(module0, hidden_states)
         intermediate_tensors0.epilog.args = record.args
-        intermediate_tensors0.epilog.outs = record.outs
 
     # Run criterion if needed
     outputs0 = [hidden_states]

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -12,26 +12,21 @@ import torch.nn.functional as F
 from torch import nn
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
 
-from pithtrain.dualpipe.execution import (
-    EpilogArgs,
-    EpilogOuts,
-    IntermediateTensors,
-    PrologArgs,
-    PrologOuts,
-)
+from pithtrain.dualpipe.execution import EpilogArgs, IntermediateTensors, PrologArgs, PrologOuts
+from pithtrain.dualpipe.layer_partition import layer_partition
 from pithtrain.dualpipe.modeling import decoder_layer_backward, decoder_layer_forward
 from pithtrain.dualpipe.utils import run_backward
-from pithtrain.layers.factory import (
-    ModelImplMode,
-    get_group_linear_cls,
-    get_linear_cls,
-)
+from pithtrain.layers.factory import ModelImplMode, get_group_linear_cls, get_linear_cls
 from pithtrain.models.interface import ForwardAttnOutput
 from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
 from pithtrain.operators.flash_attn_v4 import mla_flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
-from pithtrain.operators.token_scatter import precompute_group_indices, scatter_for_grouped_gemm
+from pithtrain.operators.token_scatter import (
+    padded_index_gather,
+    precompute_group_indices,
+    scatter_for_grouped_gemm,
+)
 
 torch._dynamo.allow_in_graph(MoELoadBalanceLossInjector)
 
@@ -557,12 +552,13 @@ class DeepseekV2LiteDecoderLayer(nn.Module):
 
         assert expert_idxs is not None
         if expand_idx is not None:
-            gathered_tokens = gathered_tokens[expand_idx]
+            gathered_tokens = padded_index_gather(gathered_tokens, expand_idx)
         output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks, ks_tensor = (
             scatter_for_grouped_gemm(gathered_tokens, expert_idxs, self.mlp.experts_per_rank)
         )
+        del gathered_tokens  # free expanded tokens; no longer needed after scatter
         outs = self.mlp.experts(output_tokens, grouped_mm_offs, ks=ks, ks_tensor=ks_tensor)
-        outs = outs[reverse_shuffle_idxs]
+        outs = padded_index_gather(outs, reverse_shuffle_idxs)
         return outs
 
     @torch.compile(fullgraph=True)
@@ -669,10 +665,7 @@ class DeepseekV2LiteModel(nn.Module):
         # Naive layer partition may cause stage -1 to have fewer layers than other stages,
         # which further leads to imbalance. So we use this partition, trying to achieve
         # a more balanced partition.
-        num_local_layers = [config.num_hidden_layers // num_stages for _ in range(num_stages)]
-        layers_per_stage_residual = config.num_hidden_layers % num_stages
-        for i in range(layers_per_stage_residual):
-            num_local_layers[(1 - (i % 2) * 2) * (i // 2) - (i % 2)] += 1
+        num_local_layers = layer_partition(config.num_hidden_layers, num_stages)
         layer_id_begin = sum(num_local_layers[:stage_id])
         layer_id_end = layer_id_begin + num_local_layers[stage_id]
         self.layers = nn.ModuleDict(
@@ -754,9 +747,6 @@ class DeepseekV2LiteModel(nn.Module):
                 dst = intermediate_tensors.layers[layer_idx]
                 for field in fields(layer_record):
                     src_rec = getattr(layer_record, field.name)
-                    # Skip records where args wasn't set (record exists but wasn't used)
-                    if not hasattr(src_rec, "args"):
-                        continue
                     dst_rec = getattr(dst, field.name)
                     for rf in fields(src_rec):
                         if hasattr(src_rec, rf.name):
@@ -778,7 +768,6 @@ class DeepseekV2LiteModel(nn.Module):
             intermediate_tensors.epilog.args = EpilogArgs(hidden_states)
             hidden_states = self.norm(hidden_states)
             hidden_states = self.lm_head(hidden_states)
-            intermediate_tensors.epilog.outs = EpilogOuts(hidden_states)
 
         return hidden_states
 
@@ -798,7 +787,6 @@ class DeepseekV2LiteModel(nn.Module):
             dy = (intermediate_tensors.epilog.args.hidden_states.grad,)
             # Clear tensor refs but keep pre-allocated record
             intermediate_tensors.epilog.args = None
-            intermediate_tensors.epilog.outs = None
             loss = None
         else:
             assert module.norm is None

--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -10,26 +10,21 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
 
-from pithtrain.dualpipe.execution import (
-    EpilogArgs,
-    EpilogOuts,
-    IntermediateTensors,
-    PrologArgs,
-    PrologOuts,
-)
+from pithtrain.dualpipe.execution import EpilogArgs, IntermediateTensors, PrologArgs, PrologOuts
+from pithtrain.dualpipe.layer_partition import layer_partition
 from pithtrain.dualpipe.modeling import decoder_layer_backward, decoder_layer_forward
 from pithtrain.dualpipe.utils import run_backward
-from pithtrain.layers.factory import (
-    ModelImplMode,
-    get_group_linear_cls,
-    get_linear_cls,
-)
+from pithtrain.layers.factory import ModelImplMode, get_group_linear_cls, get_linear_cls
 from pithtrain.models.interface import ForwardAttnOutput
 from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
 from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
-from pithtrain.operators.token_scatter import precompute_group_indices, scatter_for_grouped_gemm
+from pithtrain.operators.token_scatter import (
+    padded_index_gather,
+    precompute_group_indices,
+    scatter_for_grouped_gemm,
+)
 
 torch._dynamo.allow_in_graph(MoELoadBalanceLossInjector)
 
@@ -236,7 +231,7 @@ class Qwen3MoeGate(nn.Module):
         batch_size, seq_len, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
 
-        logits = F.linear(hidden_states.float(), self.weight.float(), None)
+        logits = F.linear(hidden_states, self.weight, None)
         scores = logits.softmax(dim=-1, dtype=torch.float32)
         topk_weight, topk_idx = torch.topk(scores, k=self.num_experts_per_tok, dim=-1, sorted=False)
 
@@ -598,12 +593,13 @@ class Qwen3MoeDecoderLayer(nn.Module):
 
         assert expert_idxs is not None
         if expand_idx is not None:
-            gathered_tokens = gathered_tokens[expand_idx]
+            gathered_tokens = padded_index_gather(gathered_tokens, expand_idx)
         output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks, ks_tensor = (
             scatter_for_grouped_gemm(gathered_tokens, expert_idxs, self.mlp.experts_per_rank)
         )
+        del gathered_tokens  # free expanded tokens; no longer needed after scatter
         outs = self.mlp.experts(output_tokens, grouped_mm_offs, ks=ks, ks_tensor=ks_tensor)
-        outs = outs[reverse_shuffle_idxs]
+        outs = padded_index_gather(outs, reverse_shuffle_idxs)
         return outs
 
     @torch.compile(fullgraph=True)
@@ -720,10 +716,7 @@ class Qwen3MoeModel(nn.Module):
 
         self.embed_tokens = nn.Embedding(vocab_size, hidden_size) if stage_id == 0 else None
 
-        num_local_layers = [config.num_hidden_layers // num_stages for _ in range(num_stages)]
-        layers_per_stage_residual = config.num_hidden_layers % num_stages
-        for i in range(layers_per_stage_residual):
-            num_local_layers[(1 - (i % 2) * 2) * (i // 2) - (i % 2)] += 1
+        num_local_layers = layer_partition(config.num_hidden_layers, num_stages)
         layer_id_begin = sum(num_local_layers[:stage_id])
         layer_id_end = layer_id_begin + num_local_layers[stage_id]
 
@@ -826,8 +819,6 @@ class Qwen3MoeModel(nn.Module):
                 dst = intermediate_tensors.layers[layer_idx]
                 for field in fields(layer_record):
                     src_rec = getattr(layer_record, field.name)
-                    if not hasattr(src_rec, "args"):
-                        continue
                     dst_rec = getattr(dst, field.name)
                     for rf in fields(src_rec):
                         setattr(dst_rec, rf.name, getattr(src_rec, rf.name))
@@ -847,7 +838,6 @@ class Qwen3MoeModel(nn.Module):
             intermediate_tensors.epilog.args = EpilogArgs(hidden_states)
             hidden_states = self.norm(hidden_states)
             hidden_states = self.lm_head(hidden_states)
-            intermediate_tensors.epilog.outs = EpilogOuts(hidden_states)
 
         return hidden_states
 
@@ -870,7 +860,6 @@ class Qwen3MoeModel(nn.Module):
             loss.detach_()
             dy = (intermediate_tensors.epilog.args.hidden_states.grad,)
             intermediate_tensors.epilog.args = None
-            intermediate_tensors.epilog.outs = None
             loss = None
         else:
             assert module.norm is None

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -259,7 +259,7 @@ def apply_fsdp(model, mesh: torch.distributed.DeviceMesh):
     other_fsdp_mesh = mesh["dp", "cp", "ep"]._flatten()
     mp = MixedPrecisionPolicy(
         param_dtype=torch.bfloat16,
-        reduce_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
         output_dtype=None,
         cast_forward_inputs=True,
     )
@@ -276,15 +276,24 @@ def apply_fsdp(model, mesh: torch.distributed.DeviceMesh):
         if model[i].norm is not None:
             assert model[i].lm_head is not None
             fully_shard(
-                model[i].norm, mesh=other_fsdp_mesh, reshard_after_forward=True, mp_policy=mp
+                model[i].norm,
+                mesh=other_fsdp_mesh,
+                reshard_after_forward=True,
+                mp_policy=mp,
             )
             fully_shard(
-                model[i].lm_head, mesh=other_fsdp_mesh, reshard_after_forward=True, mp_policy=mp
+                model[i].lm_head,
+                mesh=other_fsdp_mesh,
+                reshard_after_forward=True,
+                mp_policy=mp,
             )
         for layer in model[i].layers.values():
             if hasattr(layer.mlp, "experts"):
                 fully_shard(
-                    layer.mlp.experts, mesh=moe_fsdp_mesh, reshard_after_forward=False, mp_policy=mp
+                    layer.mlp.experts,
+                    mesh=moe_fsdp_mesh,
+                    reshard_after_forward=False,
+                    mp_policy=mp,
                 )
             fully_shard(layer, mesh=other_fsdp_mesh, reshard_after_forward=False, mp_policy=mp)
             torch.distributed.fsdp.register_fsdp_forward_method(layer, "forward_attn")

--- a/pithtrain/operators/all_to_all.py
+++ b/pithtrain/operators/all_to_all.py
@@ -15,9 +15,10 @@ _all_to_all_single = torch.compiler.disable(torch.distributed.all_to_all_single)
 # Pad all-to-all output allocations to multiples of this many rows.
 # Reduces CUDA memory fragmentation by collapsing varying allocation sizes
 # into the same caching-allocator bucket for reuse across micro-batches.
-_ALLTOALL_PAD_ALIGNMENT = 512
+_ALLTOALL_PAD_ALIGNMENT = 1024
 
 
+@torch.no_grad()
 def direct_all_to_all(
     input: torch.Tensor,
     output_split_sizes: List[int],

--- a/pithtrain/operators/cross_entropy.py
+++ b/pithtrain/operators/cross_entropy.py
@@ -1,0 +1,156 @@
+# Adapted from NVIDIA TransformerEngine (Apache 2.0)
+# https://github.com/NVIDIA/TransformerEngine
+#   transformer_engine/common/triton/cross_entropy.py  (Triton kernels)
+#   transformer_engine/pytorch/triton/cross_entropy.py  (autograd wrapper)
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Modifications: fused online-softmax + cross-entropy into a single kernel,
+# removed tensor-parallelism / label-smoothing / distributed support.
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def cross_entropy_fwd(
+    X_ptr,
+    X_stride,
+    Y_ptr,
+    Y_stride,
+    loss_ptr,
+    loss_stride,
+    n_cols,
+    n_non_ignore_ptr,
+    ignore_idx,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Fused cross-entropy forward: computes per-row loss and overwrites
+    the logit tensor in-place with mean-reduced gradients.
+
+    Each program processes one row (token position). The kernel performs
+    two passes over the vocabulary dimension:
+      1. Online softmax: numerically stable max (m) and sum-of-exp (d).
+      2. Gradient write: softmax(x_i) / N for all i, then correct the
+         target position to (softmax(x_y) - 1) / N.
+
+    The per-row loss is stored separately for later summation.
+    """
+    row = tl.program_id(0).to(tl.int64)
+    X_ptr += row * X_stride
+    y = tl.load(Y_ptr + row * Y_stride)
+
+    if y == ignore_idx:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            X_offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(X_ptr + X_offsets, 0.0, mask=X_offsets < n_cols)
+        tl.store(loss_ptr + row * loss_stride, 0.0)
+        return
+
+    n_non_ignore: tl.float32 = tl.load(n_non_ignore_ptr).to(tl.float32)
+
+    m: tl.float32 = float("-inf")
+    d: tl.float32 = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        X_offsets = i + tl.arange(0, BLOCK_SIZE)
+        X_block = tl.load(X_ptr + X_offsets, mask=X_offsets < n_cols, other=float("-inf")).to(
+            tl.float32
+        )
+        block_max = tl.max(X_block)
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(X_block - m_new))
+        m = m_new
+
+    ori_X_y = tl.load(X_ptr + y).to(tl.float32)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        X_offsets = i + tl.arange(0, BLOCK_SIZE)
+        X_block = tl.load(X_ptr + X_offsets, mask=X_offsets < n_cols, other=float("-inf"))
+        grad_dtype = X_block.dtype
+        X_block = (tl.exp(X_block.to(tl.float32) - m) / d) / n_non_ignore
+        tl.store(X_ptr + X_offsets, X_block.to(grad_dtype), mask=X_offsets < n_cols)
+
+    X_y = tl.load(X_ptr + y)
+    X_y += -1.0 / n_non_ignore
+    tl.store(X_ptr + y, X_y)
+
+    loss = -(ori_X_y - m - tl.log(d))
+    tl.store(loss_ptr + row * loss_stride, loss)
+
+
+class CrossEntropy(torch.autograd.Function):
+    """
+    Fused cross-entropy that overwrites the logit tensor with gradients
+    during the forward pass so no extra activation memory is needed.
+    """
+
+    @staticmethod
+    def forward(ctx, inp, target, ignore_index):
+        n_rows, n_cols = inp.shape
+
+        if inp.stride(-1) != 1 or inp.stride(-2) != n_cols:
+            inp = inp.contiguous()
+        if target.stride(-1) != 1:
+            target = target.contiguous()
+
+        n_non_ignore = (target != ignore_index).sum(dtype=torch.int64).view(1)
+        n_non_ignore.clamp_(min=1)
+
+        loss_1d = torch.zeros(n_rows, dtype=torch.float32, device=inp.device)
+        BLOCK_SIZE = min(65536 // 2, triton.next_power_of_2(n_cols))
+
+        cross_entropy_fwd[(n_rows,)](
+            X_ptr=inp,
+            X_stride=inp.stride(-2),
+            Y_ptr=target,
+            Y_stride=target.stride(-1),
+            loss_ptr=loss_1d,
+            loss_stride=loss_1d.stride(-1),
+            n_cols=n_cols,
+            n_non_ignore_ptr=n_non_ignore,
+            ignore_idx=ignore_index,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=32,
+        )
+
+        loss = loss_1d.sum() / n_non_ignore.float().squeeze()
+        ctx.save_for_backward(inp.detach())
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (inp,) = ctx.saved_tensors
+        inp.mul_(grad_output.to(inp.dtype))
+        return inp, None, None
+
+
+def cross_entropy(
+    inp: torch.Tensor,
+    target: torch.Tensor,
+    ignore_index: int = -100,
+) -> torch.Tensor:
+    """
+    In-place fused cross-entropy loss with mean reduction.
+
+    Overwrites ``inp`` with pre-computed gradients during the forward pass,
+    eliminating the need for a separate activation tensor.  All arithmetic
+    is performed in FP32; gradients are stored in the original dtype of
+    ``inp``.
+
+    Parameters
+    ----------
+    inp : torch.Tensor
+        Logits of shape ``(N, V)`` where N is the number of tokens and V is
+        the vocabulary size.  Modified in-place.
+    target : torch.Tensor
+        Target indices of shape ``(N,)`` with values in ``[0, V-1]``.
+    ignore_index : int
+        Target value that is ignored in loss and gradient computation.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar mean cross-entropy loss (float32).
+    """
+    return CrossEntropy.apply(inp, target, ignore_index)

--- a/pithtrain/operators/deepgemm_fp8_quantize.py
+++ b/pithtrain/operators/deepgemm_fp8_quantize.py
@@ -312,6 +312,7 @@ def fused_rowwise_kmajor_cast_to_fp8(
         block_starts,
         right=True,
     ).to(torch.int32)
+    block_to_group.clamp_(max=grouped_mm_offs.shape[0] - 1)
 
     scaling_mode = "e8m0" if _USE_E8M0_SCALES else "fp32"
 

--- a/pithtrain/operators/ep_dispatch.py
+++ b/pithtrain/operators/ep_dispatch.py
@@ -30,7 +30,7 @@ import torch.distributed as dist
 import triton
 import triton.language as tl
 
-from pithtrain.operators.token_scatter import get_pinned_buffer
+from pithtrain.operators.token_scatter import get_pinned_buffer, padded_index_gather
 
 
 @triton.jit
@@ -667,7 +667,7 @@ def moe_ep_prepare_dispatch(
 
     # Trim + gather dedup tokens for dispatch
     total_dedup = sum(dedup_input_splits)
-    dedup_sorted_tokens = hidden_states[dispatch_token_idxs[:total_dedup]]
+    dedup_sorted_tokens = padded_index_gather(hidden_states, dispatch_token_idxs[:total_dedup])
 
     return (
         dedup_sorted_tokens,

--- a/pithtrain/operators/token_scatter.py
+++ b/pithtrain/operators/token_scatter.py
@@ -9,6 +9,7 @@ import triton.language as tl
 # per-call cudaStreamSynchronize overhead from .tolist() / .item().
 
 _pinned_buffers: dict[tuple[str, torch.dtype, int], torch.Tensor] = {}
+_GEMM_ALLOC_ALIGNMENT = 1024
 
 
 def get_pinned_buffer(name: str, numel: int, dtype: torch.dtype) -> torch.Tensor:
@@ -71,8 +72,11 @@ def _scatter_for_grouped_gemm_kernel(
     hidden_size,
     stride_src_m,  # sorted_tokens.stride(0)
     stride_dst_m,  # output_tokens.stride(0)
+    m,
+    num_groups,
     BLOCK_H: tl.constexpr,
     NUM_H_BLOCKS: tl.constexpr,
+    GEMM_ALLOC_ALIGNMENT: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
 
@@ -106,6 +110,28 @@ def _scatter_for_grouped_gemm_kernel(
         pad_base = base_offset.to(tl.int64) + actual_count
         for row_off in range(my_start, my_end):
             row_base = (pad_base + row_off) * stride_dst_m
+            for i in tl.static_range(NUM_H_BLOCKS):
+                h_offs = i * BLOCK_H + tl.arange(0, BLOCK_H)
+                mask = h_offs < hidden_size
+                tl.store(
+                    output_tokens_ptr + row_base + h_offs,
+                    tl.zeros([BLOCK_H], dtype=sorted_tokens_ptr.dtype.element_ty),
+                    mask=mask,
+                )
+
+    # --- Zero rows [actual_M, M_rounded) for GEMM allocation alignment ---
+    last_group_end = tl.load(grouped_mm_offs_ptr + num_groups - 1).to(tl.int64)
+    M_rounded = (
+        (last_group_end + GEMM_ALLOC_ALIGNMENT - 1) // GEMM_ALLOC_ALIGNMENT * GEMM_ALLOC_ALIGNMENT
+    )
+    align_pad = M_rounded - last_group_end
+
+    if align_pad > 0:
+        rows_per = (align_pad + m - 1) // m
+        my_start = pid * rows_per
+        my_end = tl.minimum(my_start + rows_per, align_pad)
+        for row_off in range(my_start, my_end):
+            row_base = (last_group_end + row_off) * stride_dst_m
             for i in tl.static_range(NUM_H_BLOCKS):
                 h_offs = i * BLOCK_H + tl.arange(0, BLOCK_H)
                 mask = h_offs < hidden_size
@@ -151,6 +177,11 @@ class ScatterForGroupedGemm(torch.autograd.Function):
 
         # Over-allocate: tight upper bound, no GPU data needed (no .item() sync)
         max_m_padded = m + num_groups * (padding_alignment - 1)
+        max_m_padded = (
+            (max_m_padded + _GEMM_ALLOC_ALIGNMENT - 1)
+            // _GEMM_ALLOC_ALIGNMENT
+            * _GEMM_ALLOC_ALIGNMENT
+        )
 
         # Over-allocated output — padding rows zeroed inside the scatter kernel
         # `output_tokens` will be zeroed inside the scatter kernel.
@@ -201,8 +232,11 @@ class ScatterForGroupedGemm(torch.autograd.Function):
             hidden_size,
             sorted_tokens.stride(0),
             output_tokens.stride(0),
+            m,
+            num_groups,
             BLOCK_H=BLOCK_H,
             NUM_H_BLOCKS=NUM_H_BLOCKS,
+            GEMM_ALLOC_ALIGNMENT=_GEMM_ALLOC_ALIGNMENT,
         )
 
         # Narrow to actual padded size (removes over-allocated tail)
@@ -213,7 +247,10 @@ class ScatterForGroupedGemm(torch.autograd.Function):
         copy_stream.synchronize()
         ks = ks_cpu.tolist()
         actual_M = sum(ks)
-        output_tokens = output_tokens[:actual_M]
+        M_rounded = (
+            (actual_M + _GEMM_ALLOC_ALIGNMENT - 1) // _GEMM_ALLOC_ALIGNMENT * _GEMM_ALLOC_ALIGNMENT
+        )
+        output_tokens = output_tokens[:M_rounded]
 
         ctx.save_for_backward(reverse_shuffle_idxs)
         return output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks_tensor, ks
@@ -232,6 +269,58 @@ class ScatterForGroupedGemm(torch.autograd.Function):
         # Backward: grad_sorted_tokens[i] = grad_output_tokens[reverse_shuffle_idxs[i]]
         grad_sorted_tokens = grad_output_tokens[reverse_shuffle_idxs]
         return grad_sorted_tokens, None, None, None
+
+
+class _PaddedIndexGather(torch.autograd.Function):
+    """Gather rows from a 2-D tensor by a 1-D index, with padded allocation.
+
+    Two optimizations over plain ``input[index]``:
+
+    1. **Avoids saving the input tensor** — the backward is a scatter-add that
+       only needs the indices and the input shape, not the input values.
+    2. **Pads the output allocation** to a fixed row alignment so the CUDA
+       caching allocator sees consistent block sizes across micro-batches,
+       reducing memory fragmentation from dynamic MoE token counts.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, input: torch.Tensor, index: torch.Tensor, pad_to_multiple: int
+    ) -> torch.Tensor:
+        ctx.save_for_backward(index)
+        ctx.input_shape = input.shape
+        ctx.pad_to_multiple = pad_to_multiple
+        actual = index.shape[0]
+        padded = (actual + pad_to_multiple - 1) // pad_to_multiple * pad_to_multiple
+        buf = input.new_empty(padded, *input.shape[1:])
+        # Write directly into buf without materializing a temporary.
+        torch.index_select(input, 0, index, out=buf[:actual])
+        return buf[:actual]  # view — keeps the padded allocation alive
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (index,) = ctx.saved_tensors
+        rows = ctx.input_shape[0]
+        padded_rows = (rows + ctx.pad_to_multiple - 1) // ctx.pad_to_multiple * ctx.pad_to_multiple
+        grad_buf = torch.zeros(
+            padded_rows,
+            *ctx.input_shape[1:],
+            dtype=grad_output.dtype,
+            device=grad_output.device,
+        )
+        grad_buf[:rows].scatter_add_(0, index.unsqueeze(-1).expand_as(grad_output), grad_output)
+        return grad_buf[:rows], None, None
+
+
+def padded_index_gather(
+    input: torch.Tensor, index: torch.Tensor, pad_to_multiple: int = 1024
+) -> torch.Tensor:
+    """Memory-efficient ``input[index]`` with padded allocation.
+
+    Does not save *input* for backward, and pads the output to
+    *pad_to_multiple* rows to reduce CUDA allocator fragmentation.
+    """
+    return _PaddedIndexGather.apply(input, index, pad_to_multiple)
 
 
 def scatter_for_grouped_gemm(
@@ -281,5 +370,7 @@ def precompute_group_indices(grouped_mm_offs: torch.Tensor, M: int) -> Optional[
 
         if ARCH_MAJOR < 10:
             row_indices = torch.arange(M, device=grouped_mm_offs.device)
-            return torch.searchsorted(grouped_mm_offs, row_indices, right=True).to(torch.int32)
+            gi = torch.searchsorted(grouped_mm_offs, row_indices, right=True).to(torch.int32)
+            gi.clamp_(max=grouped_mm_offs.shape[0] - 1)
+            return gi
     return None

--- a/pithtrain/tasks/pretrain_language_model.py
+++ b/pithtrain/tasks/pretrain_language_model.py
@@ -13,7 +13,6 @@ import torch
 import torch.cuda
 import torch.distributed.checkpoint as dcp
 import torch.nn as nn
-import torch.nn.functional as F
 import wandb
 from torch.distributed._tensor import DTensor
 from torch.distributed.checkpoint import FileSystemReader
@@ -38,6 +37,7 @@ from pithtrain.modules.distributed import DistributedCfg, DistributedCtx, distri
 from pithtrain.modules.load_balance import MoELoadBalanceLossTracker
 from pithtrain.modules.logging import LoggingCfg, LoggingCtx, activate_wandb, logging_context
 from pithtrain.modules.training import TrainingCfg, TrainingCtx, training_context
+from pithtrain.operators.cross_entropy import cross_entropy
 
 
 @dataclass(init=False, slots=True)
@@ -138,9 +138,9 @@ def get_global_batch(
 
 
 def criterion(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    output = output.view(-1, output.size(-1)).float()
+    output = output.view(-1, output.size(-1))
     target = target.view(-1)
-    return F.cross_entropy(output, target, ignore_index=-100)
+    return cross_entropy(output, target, ignore_index=-100)
 
 
 @torch.no_grad()

--- a/tests/test_fsdp.py
+++ b/tests/test_fsdp.py
@@ -95,7 +95,7 @@ def apply_fsdp(model, mesh: torch.distributed.DeviceMesh, dtype):
     other_fsdp_mesh = mesh["dp", "ep"]._flatten()
     mp = MixedPrecisionPolicy(
         param_dtype=dtype,
-        reduce_dtype=dtype,
+        reduce_dtype=torch.float32,
         output_dtype=None,
         cast_forward_inputs=True,
     )

--- a/tests/test_layer_partition.py
+++ b/tests/test_layer_partition.py
@@ -1,0 +1,76 @@
+"""Tests for the DualPipeV layer partitioning algorithm."""
+
+import pytest
+
+from pithtrain.dualpipe.layer_partition import layer_partition
+
+
+@pytest.fixture(autouse=True)
+def _silence(monkeypatch):
+    """Suppress the rank-0 log print during tests."""
+    monkeypatch.setattr("pithtrain.dualpipe.layer_partition.print_msg", lambda *a, **kw: None)
+
+
+# ── Invariant tests (sweep over many configs) ──
+
+
+@pytest.mark.parametrize("S", range(1, 13), ids=lambda s: f"S={s}")
+def test_sum_length_and_positivity(S):
+    """sum == num_layers, len == num_stages, every stage >= 1."""
+    for N in range(S, S + 30):
+        layers = layer_partition(N, S)
+        assert len(layers) == S
+        assert sum(layers) == N, f"N={N}, S={S}: sum={sum(layers)}"
+        assert all(n >= 1 for n in layers), f"N={N}, S={S}: {layers}"
+
+
+@pytest.mark.parametrize("S", range(1, 13), ids=lambda s: f"S={s}")
+def test_max_minus_min_at_most_one(S):
+    """Every stage gets either floor or ceil of the average."""
+    for N in range(S, S + 30):
+        layers = layer_partition(N, S)
+        assert max(layers) - min(layers) <= 1, f"N={N}, S={S}: {layers}"
+
+
+@pytest.mark.parametrize("S", range(3, 13), ids=lambda s: f"S={s}")
+def test_edges_le_inner(S):
+    """Edge stages (0 and -1) are <= every inner stage."""
+    for N in range(S, S + 30):
+        layers = layer_partition(N, S)
+        inner_min = min(layers[1:-1])
+        assert layers[0] <= inner_min, f"N={N}, S={S}: {layers}"
+        assert layers[-1] <= inner_min, f"N={N}, S={S}: {layers}"
+
+
+@pytest.mark.parametrize("S", range(2, 13, 2), ids=lambda s: f"S={s}")
+def test_dualpipev_phase_balance(S):
+    """abs(phase0_layers - phase1_layers) <= 1 for each pp_rank."""
+    pp_size = S // 2
+    for N in range(S, S + 30):
+        layers = layer_partition(N, S)
+        for k in range(pp_size):
+            diff = abs(layers[k] - layers[S - 1 - k])
+            assert diff <= 1, (
+                f"N={N}, S={S}, pp_rank={k}: "
+                f"{layers[k]} vs {layers[S - 1 - k]} (diff={diff}), {layers}"
+            )
+
+
+# ── Exact-value tests for production configs ──
+
+
+def test_qwen3_30b_a3b_pp4():
+    """Qwen3-30B-A3B: 48 layers, pp=4 (8 stages)."""
+    assert layer_partition(48, 8) == [6, 6, 6, 6, 6, 6, 6, 6]
+
+
+def test_deepseek_v2_lite_pp4():
+    """DeepSeek-V2-Lite: 27 layers, pp=4 (8 stages)."""
+    assert layer_partition(27, 8) == [3, 4, 4, 4, 3, 3, 3, 3]
+
+
+def test_small_cases():
+    assert layer_partition(1, 1) == [1]
+    assert layer_partition(2, 2) == [1, 1]
+    assert layer_partition(3, 2) == [2, 1]
+    assert layer_partition(5, 3) == [2, 2, 1]


### PR DESCRIPTION
- Remove EpilogOuts/epilog_b (dead code; logits not needed after loss)
- Remove Stage2/Stage4 args and outs (only ctx needed for a2a backward)
- Add padded_index_gather: avoids saving input for backward + reduces CUDA allocator fragmentation via fixed-alignment output buffers
- Free stage-boundary tensor storage early via untyped_storage().resize_(0) after async all-to-all consumers complete (sorted_tokens after Stage 2, gathered_tokens after Stage 3, stage3 moe_outs after Stage 4)
- Add fwd_comm_deferred_free to ExecutionCtx for clean deferred-free in the overlapped path without changing stage function signatures
- Add layer_partition() for memory-aware pipeline stage assignment
- Add per-layer saved-tensor profiling with weight/activation distinction

Co-authored-by: Hao Kang <89672451+haok1402@users.noreply.github.com>