### PR TITLE
Fuse SwiGLU silu(gate) * up into a Triton autograd op

### DIFF
--- a/pithtrain/dualpipe/dualpipev.py
+++ b/pithtrain/dualpipe/dualpipev.py
@@ -203,7 +203,6 @@ class DualPipeV(nn.Module):
                     None,
                     self.intermediate_tensors_chunks[phase][chunk_id],
                 )
-                # run_backward(outputs, output_grads)
         # Note: intermediate_tensors is pre-allocated and reused; backward clears tensor refs inside
         WeightGradStore.enabled = False
         if enable_zb:

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -22,6 +22,7 @@ from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBa
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
 from pithtrain.operators.flash_attn_v4 import mla_flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
+from pithtrain.operators.silu_mul import silu_mul
 from pithtrain.operators.token_scatter import (
     padded_index_gather,
     precompute_group_indices,
@@ -195,12 +196,11 @@ class DeepseekV2LiteMLP(nn.Module):
         self.gate_proj = LinearCls(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = LinearCls(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = LinearCls(self.intermediate_size, self.hidden_size, bias=False)
-        self.act_fn = nn.SiLU()
 
     def forward(self, x):
-        g = self.act_fn(self.gate_proj(x))
+        g = self.gate_proj(x)
         u = self.up_proj(x)
-        return self.down_proj(g * u)
+        return self.down_proj(silu_mul(g, u))
 
 
 class DeepseekV2LiteExperts(nn.Module):
@@ -220,7 +220,6 @@ class DeepseekV2LiteExperts(nn.Module):
         self.gate_proj = GroupLinearCls(num_experts, self.hidden_size, self.intermediate_size)
         self.up_proj = GroupLinearCls(num_experts, self.hidden_size, self.intermediate_size)
         self.down_proj = GroupLinearCls(num_experts, self.intermediate_size, self.hidden_size)
-        self.act_fn = nn.SiLU()
 
     def forward(
         self,
@@ -231,9 +230,9 @@ class DeepseekV2LiteExperts(nn.Module):
     ):
         gi = precompute_group_indices(grouped_mm_offs, x.shape[0])
         kwargs = dict(grouped_mm_offs=grouped_mm_offs, ks=ks, ks_tensor=ks_tensor, group_indices=gi)
-        g = self.act_fn(self.gate_proj(x, **kwargs))
+        g = self.gate_proj(x, **kwargs)
         u = self.up_proj(x, **kwargs)
-        return self.down_proj(g * u, **kwargs)
+        return self.down_proj(silu_mul(g, u), **kwargs)
 
 
 class DeepseekV2LiteMoEGate(nn.Module):

--- a/pithtrain/models/qwen3_30b_a3b.py
+++ b/pithtrain/models/qwen3_30b_a3b.py
@@ -20,6 +20,7 @@ from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBa
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
 from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention.standard import ring_attention_func
+from pithtrain.operators.silu_mul import silu_mul
 from pithtrain.operators.token_scatter import (
     padded_index_gather,
     precompute_group_indices,
@@ -147,10 +148,9 @@ class Qwen3MoeMLP(nn.Module):
         self.gate_proj = LinearCls(hidden_size, intermediate_size, bias=False)
         self.up_proj = LinearCls(hidden_size, intermediate_size, bias=False)
         self.down_proj = LinearCls(intermediate_size, hidden_size, bias=False)
-        self.act_fn = nn.SiLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return self.down_proj(silu_mul(self.gate_proj(x), self.up_proj(x)))
 
 
 class Qwen3MoeExperts(nn.Module):
@@ -173,7 +173,6 @@ class Qwen3MoeExperts(nn.Module):
         self.gate_proj = GroupLinearCls(num_experts, hidden_size, moe_intermediate_size)
         self.up_proj = GroupLinearCls(num_experts, hidden_size, moe_intermediate_size)
         self.down_proj = GroupLinearCls(num_experts, moe_intermediate_size, hidden_size)
-        self.act_fn = nn.SiLU()
 
     def forward(
         self,
@@ -184,9 +183,9 @@ class Qwen3MoeExperts(nn.Module):
     ) -> torch.Tensor:
         gi = precompute_group_indices(grouped_mm_offs, x.shape[0])
         kwargs = dict(grouped_mm_offs=grouped_mm_offs, ks=ks, ks_tensor=ks_tensor, group_indices=gi)
-        g = self.act_fn(self.gate_proj(x, **kwargs))
+        g = self.gate_proj(x, **kwargs)
         u = self.up_proj(x, **kwargs)
-        return self.down_proj(g * u, **kwargs)
+        return self.down_proj(silu_mul(g, u), **kwargs)
 
 
 class Qwen3MoeGate(nn.Module):

--- a/pithtrain/operators/silu_mul.py
+++ b/pithtrain/operators/silu_mul.py
@@ -1,0 +1,143 @@
+"""
+Fused SwiGLU-style ``silu(gate) * up`` autograd function.
+
+Eager PyTorch implements this as two element-wise kernels in the forward pass
+(``silu`` then ``mul``) and several kernels in the backward pass, all of which
+are memory-bound. In addition, autograd saves ``sigmoid(gate)``, ``silu(gate)``,
+and ``up`` for backward, which wastes activation memory on a recomputable
+intermediate.
+
+The kernels here:
+
+- fuse the forward ``silu(gate) * up`` into one Triton kernel (two loads,
+  one store), and
+- fuse the backward into one Triton kernel that recomputes ``silu`` /
+  ``sigmoid`` on the fly (three loads, two stores).
+
+Only ``gate`` and ``up`` are saved for backward — ``silu(gate)`` is no longer
+stored as an activation.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _silu_mul_fwd_kernel(
+    gate_ptr,
+    up_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Compute ``out = silu(gate) * up`` element-wise in one pass."""
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    gate = tl.load(gate_ptr + offs, mask=mask)
+    up = tl.load(up_ptr + offs, mask=mask)
+
+    gate_f = gate.to(tl.float32)
+    up_f = up.to(tl.float32)
+    silu = gate_f * tl.sigmoid(gate_f)
+    out = silu * up_f
+
+    tl.store(out_ptr + offs, out.to(up.dtype), mask=mask)
+
+
+@triton.jit
+def _silu_mul_bwd_kernel(
+    grad_out_ptr,
+    gate_ptr,
+    up_ptr,
+    grad_gate_ptr,
+    grad_up_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Compute ``grad_gate`` and ``grad_up`` element-wise in one pass.
+
+    With ``s = silu(gate)`` and ``σ = sigmoid(gate)``:
+        grad_up   = grad_out * s
+        grad_gate = grad_out * up * σ * (1 + gate - s)
+    """
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    grad_out = tl.load(grad_out_ptr + offs, mask=mask)
+    gate = tl.load(gate_ptr + offs, mask=mask)
+    up = tl.load(up_ptr + offs, mask=mask)
+
+    grad_out_f = grad_out.to(tl.float32)
+    gate_f = gate.to(tl.float32)
+    up_f = up.to(tl.float32)
+
+    sig = tl.sigmoid(gate_f)
+    silu = gate_f * sig
+
+    grad_up = grad_out_f * silu
+    grad_gate = grad_out_f * up_f * sig * (1.0 + gate_f - silu)
+
+    tl.store(grad_gate_ptr + offs, grad_gate.to(gate.dtype), mask=mask)
+    tl.store(grad_up_ptr + offs, grad_up.to(up.dtype), mask=mask)
+
+
+_BLOCK_SIZE = 1024
+
+
+class _SiLUMul(torch.autograd.Function):
+    """Fused SwiGLU activation that saves only ``gate`` and ``up``."""
+
+    @staticmethod
+    def forward(ctx, gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+        assert gate.shape == up.shape, f"shape mismatch: {gate.shape} vs {up.shape}"
+        assert gate.dtype == up.dtype, f"dtype mismatch: {gate.dtype} vs {up.dtype}"
+        assert gate.is_contiguous(), "gate must be contiguous"
+        assert up.is_contiguous(), "up must be contiguous"
+        ctx.save_for_backward(gate, up)
+        out = torch.empty_like(gate)
+        n = gate.numel()
+        grid = (triton.cdiv(n, _BLOCK_SIZE),)
+        _silu_mul_fwd_kernel[grid](gate, up, out, n, BLOCK_SIZE=_BLOCK_SIZE)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        gate, up = ctx.saved_tensors
+        assert grad_output.shape == gate.shape, (
+            f"grad_output shape {grad_output.shape} != gate shape {gate.shape}"
+        )
+        assert grad_output.dtype == gate.dtype, (
+            f"grad_output dtype {grad_output.dtype} != gate dtype {gate.dtype}"
+        )
+        assert grad_output.is_contiguous(), "grad_output must be contiguous"
+        grad_gate = torch.empty_like(gate)
+        grad_up = torch.empty_like(up)
+        n = gate.numel()
+        grid = (triton.cdiv(n, _BLOCK_SIZE),)
+        _silu_mul_bwd_kernel[grid](
+            grad_output, gate, up, grad_gate, grad_up, n, BLOCK_SIZE=_BLOCK_SIZE
+        )
+        return grad_gate, grad_up
+
+
+def silu_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Fused ``silu(gate) * up`` with a single-kernel backward.
+
+    Parameters
+    ----------
+    gate, up : torch.Tensor
+        Same-shape, same-dtype tensors produced by the gate and up projections
+        of a SwiGLU-style MLP.
+
+    Returns
+    -------
+    torch.Tensor
+        Element-wise ``silu(gate) * up`` in the same dtype as the inputs.
+    """
+    return _SiLUMul.apply(gate, up)

--- a/tests/test_silu_mul.py
+++ b/tests/test_silu_mul.py
@@ -1,0 +1,51 @@
+"""
+Correctness tests for the fused ``silu(gate) * up`` operator.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from pithtrain.operators.silu_mul import silu_mul
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+
+def _ref_forward(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    return F.silu(gate) * up
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1),
+        (128, 768),
+        (4096, 2048),
+        (8192, 4096),
+        (1023, 777),  # non-multiple of BLOCK_SIZE
+    ],
+)
+def test_silu_mul_forward_backward(shape, dtype):
+    torch.manual_seed(0)
+    device = "cuda"
+
+    gate_ref = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+    up_ref = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+    gate = gate_ref.detach().clone().requires_grad_()
+    up = up_ref.detach().clone().requires_grad_()
+
+    out_ref = _ref_forward(gate_ref, up_ref)
+    out = silu_mul(gate, up)
+
+    atol = 1e-2
+    rtol = 1e-2
+    torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+    out_ref.backward(grad_out)
+
+    torch.testing.assert_close(gate.grad, gate_ref.grad, atol=atol, rtol=rtol)
+    torch.testing.assert_close(up.grad, up_ref.grad, atol=atol, rtol=rtol)


### PR DESCRIPTION
Eager PyTorch implements `silu(gate) * up` as separate element-wise kernels and saves three activations (`sigmoid(gate)`, `silu(gate)`, `up`) for backward. Since the Qwen3 and DeepSeek-V2-Lite MLP/expert paths are not wrapped in torch.compile, nothing fuses these ops at runtime and the extra `silu(gate)` tensor is wasted activation memory.

Add `pithtrain/operators/silu_mul.py` with a custom autograd Function backed by two Triton kernels: the forward does `silu(gate) * up` in one pass, and the backward recomputes `silu` / `sigmoid` on the fly and writes both `grad_gate` and `grad_up` from a single kernel. Only `gate` and `up` are saved for backward, dropping one activation tensor per MLP/expert layer.

Wire the op into `Qwen3MoeMLP` / `Qwen3MoeExperts` and the DeepSeek-V2- Lite MLP/experts counterparts, replacing the `nn.SiLU()` + elementwise multiply. Add correctness tests against `F.silu(gate) * up` across bf16/fp32 and several shapes including non-BLOCK_SIZE-aligned ones.