### PR TITLE
Add claude skill for adding a new MoE model

### DIFF
--- a/.claude/skills/add-new-model/SKILL.md
+++ b/.claude/skills/add-new-model/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: add-new-model
+description: Adds support for a new MoE language model to PithTrain. Use when the user asks to "add support for model X", "implement model Y in pithtrain", "port model Z", or otherwise integrate a new MoE architecture. Scope covers the model file, all framework wiring (setup_model, apply_fsdp, test_fsdp), optional checkpoint conversion, and running training + inference tests from pp=1/ep=1 up to pp=2/ep=2.
+argument-hint: <hf-id-or-snapshot-path> [model-short-name]
+---
+
+# Add a New Model to PithTrain
+
+End-to-end workflow for integrating a new MoE language model. This file is
+the entry point: it tells you the phase order, the gates between phases,
+and which `reference/*.md` to load before each phase. Do not try to do
+everything from memory — load the reference file for the phase you're in.
+
+## Input
+
+One of the following:
+
+- **HuggingFace model ID** (e.g. `"mistralai/Mixtral-8x7B-v0.1"`). Used as the
+  `--hf-id` for `snapshot_download`, and as the `from_pretrained` source for
+  config and tokenizer.
+- **Local snapshot path** (a directory containing `config.json`,
+  `model*.safetensors`, `tokenizer*` etc.). Treat it exactly like the HF
+  ID case — `AutoConfig.from_pretrained(path)` works on both. The snapshot
+  itself came from HF, so online reference material (HF's
+  `modeling_<model>.py`, TorchTitan, OpenAI release repo, upstream papers)
+  is still fair game and should be consulted.
+
+Optionally a **model short name** (filename stem, e.g. `mixtral_8x7b`). If
+the user doesn't give one, derive it from the HF ID by lowercasing and
+replacing `/` and `-` with `_`. Confirm with the user before using.
+
+## Hard rules (apply in every phase)
+
+These are non-negotiable. Violating any of them will cost time later —
+in most cases that's exactly how past bugs landed.
+
+1. **Mirror HuggingFace, not our existing models.** Class names, attribute
+   names, and tensor structure (fused vs split) must match HF's
+   `modeling_<model>.py`. *Do not* base the new model on Qwen3 / DeepSeek-V2
+   / GPT-OSS and rename — that path produced the GPT-OSS
+   `gate`/`router` mismatch. See `reference/conventions.md`.
+2. **`fullgraph=True` for all three hot regions.** `_forward_attn_compute`,
+   router/gate `compute`, and `forward_aggregate` must each carry
+   `@torch.compile(fullgraph=True)`. Never reach for `fullgraph=False`.
+   See `reference/compile.md`.
+3. **Shared experts live in `forward_attn`, not `forward_aggregate`.** If
+   the model has shared experts (e.g. DeepSeek-V2), fold them into the
+   residual at the end of `_forward_attn_compute`. See
+   `reference/protocol.md`.
+4. **Check `nvidia-smi` before every GPU command.** This is a shared
+   cluster. Free GPUs can change between commands; don't reuse indices.
+   `nvidia-smi --query-gpu=index,memory.used,memory.free --format=csv` and
+   pick indices with `memory.used < 1000 MiB`. Do this once per
+   invocation, not once at the start of the whole skill.
+5. **Test timeouts stay short (120–180s).** Do not set a 10-minute timeout
+   and walk away — if a test hasn't progressed in 3 minutes, it's hanging
+   (likely torch.compile retrace). Kill and diagnose.
+6. **When tests fail, diagnose before relaxing anything.** Print actual
+   magnitudes. A 6-order-of-magnitude gradient discrepancy is not bf16
+   noise. Never loosen thresholds or add name-based skips as a first move.
+7. **Reject unused process-group arguments explicitly.** If a model's
+   `__init__` accepts a group it does not actually implement (e.g.
+   `cp_group` on a model with no ring-attention path), silently ignoring
+   it will produce wrong results when a real group is eventually passed.
+   Raise `NotImplementedError` when `group is not None and group.size() > 1`.
+   See `reference/protocol.md` §init-requirements.
+8. **Thread config values through `__init__`; don't hardcode them.** Any
+   value that appears in HF's `config.json` is a per-checkpoint knob —
+   read it from the config even if every released checkpoint currently
+   ships the same value. Only true architectural constants (paper
+   coefficients, spec-defined magic numbers) stay as module-level
+   literals, and they get a one-line comment naming the source. See
+   `reference/conventions.md` §thread-config.
+9. **Never stage `.claude/`, `CLAUDE.md`, or `docs/` in commits.**
+
+## Phase overview
+
+Phases 1–4 are modeling + training correctness. Phases 5–6 are real-weight
+inference (only needed if the user wants to generate from trained / released
+weights). **Phase 5 is skippable** when the user only cares about training
+from scratch.
+
+| Phase | Goal | Gate to next phase |
+|-------|------|-------------------|
+| 0 | Analyze HF's reference implementation | Have class/attribute/shape/config inventory |
+| 1 | Write `pithtrain/models/<model>.py` | Imports cleanly; `reference_forward` runs |
+| 2 | Wire into `pithtrain/modules/training.py` + `tests/test_fsdp.py` + example config | Example config mirrors upstream; imports clean |
+| 3 | Single-GPU sanity test | `reference_forward == 5-stage path` (rel < 0.8) |
+| 4 | FSDP scaling (pp=1/ep=1 → 2/2) | All 4 configs pass |
+| 5 | *(If needed)* Checkpoint converter + round-trip | `hf → dcp → hf → transformers.load` succeeds |
+| 6 | *(If needed)* Ad-hoc inference test | Coherent text from real weights |
+
+Do not skip ahead. Each phase is a gate: if phase N fails, do not move to
+phase N+1. If you're tempted to, stop and read `reference/pitfalls.md`.
+
+---
+
+## Phase 0 — Analyze the HF reference
+
+Before writing any code, inventory what you need to match.
+
+**Load `reference/conventions.md` before starting this phase.** It has
+the diagnostic commands (grep class names, grep attribute names,
+safetensors shape dump) under §Quick diagnostic commands.
+
+Work through these sources in order:
+
+1. **`modeling_<model>.py`** — class names, attribute names, fused vs
+   split projections, special-case features (shared experts, sinks,
+   sliding window, YaRN RoPE, clamped SwiGLU, attention biases).
+2. **A safetensors shard** — actual expert-weight shapes and dtypes,
+   not comments.
+3. **TorchTitan / Megatron-LM** reference for this model — the
+   training-framework-consensus expert layout (`[E, out, in]` vs
+   `[E, in, out]`).
+4. **`configuration_<model>.py`** — every default in
+   `<Model>Config.__init__`. When model-specific defaults disagree
+   with a generic fallback path, match the model-specific default
+   (see `reference/conventions.md` §example-config).
+5. **HF's MLP / activation forward** — read the math directly. Don't
+   trust `config.hidden_act` to tell you the whole activation. See
+   `reference/conventions.md` §activation-math.
+
+Record in a scratch doc (not a committed file): class names, attribute
+names, expert tensor layout, fused/split projections, per-checkpoint
+knobs (thread through `__init__`) vs architectural constants (module
+literals with a source comment), process groups the model accepts but
+doesn't implement (reject via `NotImplementedError`; see
+`reference/protocol.md` §init-requirements), and any special-case
+features that map to entries in `reference/pitfalls.md`.
+
+**Gate:** you can articulate exactly which class names, attribute names,
+tensor shapes, and config knobs you will wire. If any item is a guess,
+go back and `print()` it from the actual data.
+
+---
+
+## Phase 1 — Write `pithtrain/models/<model>.py`
+
+**Load `reference/protocol.md` and `reference/compile.md` before starting.**
+
+1. Start from `templates/model_skeleton.py`. It is a structural outline
+   (NOT a copy of Qwen3). Fill in the `TODO` placeholders with the HF-
+   derived names and shapes from phase 0.
+2. Implement in this order:
+   - RotaryEmbedding (mirror HF's)
+   - Attention (mirror HF's kernel choice — flash_attn for standard MHA/GQA,
+     flex_attention for sinks/sliding)
+   - Experts module
+   - Router / Gate
+   - MLP (the MoE block that wires router + experts)
+   - DecoderLayer (the 5-stage split)
+   - Model (forward / backward / stage-record copy)
+3. Checklist for the decoder layer:
+   - [ ] `self.idx = layer_idx`
+   - [ ] `self.mlp.ep_size` and `self.mlp.ep_group` exposed (so
+         `DecoderLayerMlpProtocol` is satisfied)
+   - [ ] `@torch.compile(fullgraph=True)` on `_forward_attn_compute`,
+         router/gate `compute`, and `forward_aggregate`
+   - [ ] Shared experts (if any) fold into residual at the end of
+         `_forward_attn_compute`, *before* the return
+   - [ ] `reference_forward` runs eager (no compile) and is numerically
+         equivalent to `forward_attn → forward_mlp → forward_aggregate`
+   - [ ] `forward_mlp` truncates expert input by `sum(ks)` if the expert
+         block has biases or elementwise post-ops (prevents 0*NaN=NaN in
+         backward)
+   - [ ] `forward_mlp` uses `padded_index_gather` (not raw indexing) for
+         both expand and reverse shuffle
+4. Checklist for the model class:
+   - [ ] Uses `layer_partition` from `pithtrain/dualpipe/layer_partition.py`
+   - [ ] `forward` copies *every* stage record (including stages 2 and 4,
+         which only have `.ctx`) into the pre-allocated
+         `IntermediateTensors.layers[layer_idx]`. Iterate with
+         `dataclasses.fields`, don't skip any.
+   - [ ] `backward` is a `@staticmethod`, walks layers in reverse, drives
+         `decoder_layer_backward`, and runs the prolog backward via
+         `run_backward(record.outs, dx)`.
+
+**Gate:** file imports cleanly (`python -c "from pithtrain.models.<model> import <Model>"`).
+
+---
+
+## Phase 2 — Wire into the training framework
+
+No new reference file needed — the changes are small and mechanical.
+
+1. `pithtrain/modules/training.py`:
+   - Import the new `<Model>Model` class.
+   - Add a branch in `setup_model`:
+     ```python
+     elif module_config.model_type == "<model_type>":
+         ModelClass = <Model>Model
+         model_kwargs = {"cp_group": cp_group}  # or {} if no CP support
+     ```
+   - Add the new class to the `apply_fsdp` `isinstance` assertion tuple.
+   - Add the HF ID to the `TrainingCfg.model` `Literal[...]` union (if
+     the user wants the HF ID to be an accepted value; config-path
+     usage doesn't require this).
+2. `tests/test_fsdp.py`:
+   - Import the new model + router/gate class (+ Experts class if it
+     stores raw `nn.Parameter` expert weights — see
+     `reference/pitfalls.md`).
+   - Add the new class to the `apply_fsdp` `isinstance` assertion tuple.
+   - Add a branch in the `config.model_type` switch in `main`. Slice
+     `num_hidden_layers` down to 8 (and any parallel arrays like
+     `layer_types`) to keep the test fast.
+   - Add a `fill_weights` branch if:
+     - The expert module stores raw `nn.Parameter` (not `GroupLinear`).
+       Without this, expert weights default to zero and the MoE subtree
+       silently produces all-zero outputs — see `reference/pitfalls.md`.
+     - The router/gate has new Parameters beyond `weight` (e.g. a
+       per-expert `bias`).
+   - Verify `shard_experts` can detect the experts module. If using
+     raw `nn.Parameter`, the fallback gate on `gate_up_proj` already
+     handles it. If the Parameter name is different, extend the fallback
+     — gate on the distinctive weight name, *not* on `num_experts` alone
+     (the router has `num_experts` too and must not be sharded).
+3. Add the model config and HF ID to the `models` list at the bottom of
+   `tests/test_fsdp.py`.
+4. Write `examples/pretrain_language_model/<model>/config.json`. Mirror
+   upstream HF's `config.json` field-by-field — including every nested
+   block (`rope_scaling`, `quantization_config`, etc.). See
+   `reference/conventions.md` §example-config for the diff command and
+   the three layered defaults you need to reconcile.
+
+**Gate:** `python -c "import tests.test_fsdp"` imports cleanly AND the
+example-config diff is either empty or has a documented reason for each
+remaining difference.
+
+---
+
+## Phase 3 — Single-GPU sanity test
+
+**Load `reference/testing.md`.** Tier 1 there is the whole phase:
+reference template, tiny-config setup, reference-vs-5-stage comparison,
+and the `rel < 0.8` bf16-noise bound. Ad-hoc test file (not committed);
+base on `tests/test_gpt_oss_single_gpu.py`. Single GPU, `timeout 180`.
+
+**Gate:** assertion passes with `rel < 0.8`, logits and gradients are
+finite.
+
+---
+
+## Phase 4 — FSDP scaling (training correctness)
+
+**Keep `reference/testing.md` loaded.** It owns the ladder: full
+`torchrun` commands for pp=1/ep=1 → pp=2/ep=1 → pp=1/ep=2 → pp=2/ep=2,
+what each config adds, thresholds, and the failure decision tree.
+
+Run the ladder in that order. After each step, stop and diagnose
+before continuing if anything fails. `nvidia-smi` before each run.
+Timeouts 120–180s; past that it's hanging (compile retrace or
+deadlocked all-to-all) — kill, don't raise.
+
+**Gate:** all 4 configs pass (loss `rtol=atol=1e-3`, per-param
+`calc_diff < 1e-2`).
+
+---
+
+## Phase 5 — Checkpoint converter (only if needed)
+
+**Skip this phase entirely** if the user only wants training from scratch
+(no real released weights involved). The generic path in
+`convert_checkpoint.py` already handles un-quantized, un-transposed HF
+checkpoints — Qwen3 and DeepSeek-V2 work with no model-specific branch.
+
+**Add a branch only if one of the following applies:**
+
+- The released weights are quantized (MXFP4, GPTQ, AWQ, FP8, etc.).
+- The HF live tensor layout differs from your model's in-memory layout
+  (e.g. our `[E, out, in]` vs HF's `[E, in, out]`).
+- HF's key structure differs from ours (e.g. per-expert indexed vs
+  stacked, fused vs split projections). This should be rare if you
+  followed phase 0 faithfully — ideally our model mirrors HF's structure
+  so the converter is trivial.
+
+**Load `reference/checkpoint.md` before starting this phase.**
+
+1. Implement `_hf2dcp_<model>` in `pithtrain/tasks/convert_checkpoint.py`.
+   Gate on a `_is_<model>` probe of `config.json` `model_type`.
+2. Implement `_dcp2hf_<model>` (or extend `_stack_experts`) at the same
+   time — the round-trip test is what catches layout bugs.
+3. Write an `examples/convert_checkpoint/<model>/script.py` that
+   downloads + converts. Mirror
+   `examples/convert_checkpoint/gpt-oss-20b/script.py`.
+4. Run the round-trip: hf → dcp → hf → `transformers.AutoModelForCausalLM.from_pretrained`.
+   Compare `state_dict()` element-wise against HF's own BF16 dequant.
+   Expected `max_abs_diff == 0`.
+
+**Gate:** round-trip succeeds, one expert weight compares element-wise
+equal (not just norms!) against HF's live tensor.
+
+---
+
+## Phase 6 — Ad-hoc inference test (only if needed)
+
+Only needed if the user wants to verify that real weights produce coherent
+text. **This test is not committed** — it's model-specific and lives as a
+scratch file.
+
+1. Start from `templates/inference_test.py` — the DualPipeV
+   autoregressive harness, parameterized for any `<Model>Model`. Fill
+   in the model-class import and HF ID default.
+2. Run the same pp/ep scaling ladder as phase 4 (same torchrun form,
+   replace `tests/test_fsdp.py` with `tests/test_<model>_inference.py`
+   and drop `--model <cfg>`). Each config should print coherent
+   continuations.
+3. Compare outputs across configurations — they should produce
+   identical tokens (within bf16 noise). If a specific config produces
+   gibberish, diagnose by layer/stage — do not loosen expectations.
+
+**Gate:** coherent text from real released weights, identical (bf16-noise
+equivalent) across pp/ep configurations.
+
+---
+
+## Pre-PR self-review
+
+Three sweeps on the new files before opening the PR — low-noise,
+high-signal self-reviews that save a review round-trip:
+
+1. **Function-scope imports.** Only justified for circular imports or
+   heavy optional deps. Ruff doesn't flag it; reviewers will. Grep for
+   indented `import`/`from` in the new model file; move them to
+   module level.
+2. **Dangling `docs/`, `CLAUDE.md`, `.claude/` pointers in comments or
+   docstrings.** Those paths aren't committed, so any pointer is a
+   broken link. Grep the new files and inline the derivation or delete.
+3. **Unused parameters for interface compatibility.** Accept them
+   (e.g. `cp_group` for protocol parity), then either prefix with `_`
+   or `raise NotImplementedError` when `size() > 1` (Hard Rule 7).
+   Bare unused params trip pyright/pylance.
+
+## Common failure modes → where to look
+
+| Symptom | First thing to read |
+|---------|-------------------|
+| Single-GPU `rel > 0.8` | `reference/pitfalls.md` §compile-noise |
+| All-zero gradient warnings on MoE params | `reference/pitfalls.md` §fill-weights |
+| FSDP loss matches but grads don't | `reference/testing.md` §label-scaling + `reference/pitfalls.md` §nan-padding |
+| `RuntimeError: tensor data is not allocated yet` | Wrong reshard settings — check `apply_fsdp` |
+| Inference gibberish but FSDP passed | `reference/checkpoint.md` §weight-norm-comparison + `reference/conventions.md` §example-config + §thread-config + §activation-math |
+| Wrong results only when a real `cp_group` is passed | `reference/protocol.md` §init-requirements (silent-ignore of unused groups) |
+| "invalid gradient shape" in stage 4 backward | `reference/protocol.md` §stage-record-copy |
+| `compile-inside-compile` on attention | `reference/compile.md` §flex-unwrap |
+| Left-padded prompts give gibberish on short inputs | `reference/pitfalls.md` §trim-to-shortest |
+
+## Reference files
+
+- `reference/protocol.md` — 5-stage protocol, `Model.forward`/`backward`, stage-record copy
+- `reference/conventions.md` — naming, tensor layout, canonical keys
+- `reference/compile.md` — three `@torch.compile(fullgraph=True)` hot regions, unwrap patterns
+- `reference/checkpoint.md` — hf2dcp/dcp2hf recipes, when to add, round-trip validation
+- `reference/testing.md` — pp/ep scaling ladder, test_fsdp wiring, label scaling
+- `reference/pitfalls.md` — NaN padding, `.view()` vs `.transpose()`, silent-zero experts, etc.
+
+## Templates
+
+- `templates/model_skeleton.py` — structural outline with HF-derived placeholders
+- `templates/inference_test.py` — DualPipeV autoregressive harness

--- a/.claude/skills/add-new-model/reference/checkpoint.md
+++ b/.claude/skills/add-new-model/reference/checkpoint.md
@@ -1,0 +1,322 @@
+# Checkpoint Conversion (hf2dcp / dcp2hf)
+
+**First: decide whether you need a model-specific converter branch at
+all.** The generic path in `pithtrain/tasks/convert_checkpoint.py`
+handles un-quantized, un-transposed HF checkpoints — Qwen3 and
+DeepSeek-V2 round-trip through it with no model-specific code.
+
+## When to add a model-specific branch
+
+Add a `_hf2dcp_<model>` / `_dcp2hf_<model>` branch **only if** one of
+these applies:
+
+1. **Quantized released weights** — MXFP4, GPTQ, AWQ, FP8, bitsandbytes,
+   etc. Need to dequantize to BF16 before writing DCP.
+2. **Layout mismatch** — our in-memory layout (`[E, out, in]`) differs
+   from HF's live Parameter layout (`[E, in, out]`). Need a
+   `.transpose(-2, -1)` at the `dcp2hf` boundary to give downstream
+   consumers HF's native layout.
+3. **Structural mismatch** — this should be rare. If you followed the
+   conventions (fused `gate_up_proj` stays fused, router named `router`,
+   etc.), there is nothing to rename or split in the converter.
+
+If none of those apply: skip this whole file. The generic
+`hf2dcp` / `dcp2hf` already works.
+
+## Working on a quantized checkpoint
+
+### Step 1 — Identify the format
+
+Open the safetensors index and print shapes:
+
+```python
+import json
+from safetensors import safe_open
+from pathlib import Path
+
+hf_path = Path("<snapshot>")
+with open(hf_path / "model.safetensors.index.json") as f:
+    index = json.load(f)
+shards = set(index["weight_map"].values())
+
+for shard in sorted(shards):
+    with safe_open(str(hf_path / shard), framework="pt", device="cpu") as f:
+        for k in f.keys():
+            t = f.get_tensor(k)
+            print(k, tuple(t.shape), t.dtype)
+```
+
+Key suffixes to look for:
+- `_blocks`, `_scales` → MXFP4 (GPT-OSS) or MXINT
+- `_qweight`, `_qzeros`, `_scales` → GPTQ, AWQ
+- `_scale_inv` → FP8
+
+**Never trust comments about the on-disk layout — always verify from
+the shape.** The GPT-OSS MXFP4 bug burned days because the original
+code trusted a `[E, hidden, 2*inter]` comment while the actual prefix
+was `[E, 2*inter, G, 16]` = `[E, 2*inter]` = `[E, out]`.
+
+### Step 2 — Determine the axis convention
+
+Packed tensor shape = `[prefix..., quant_axis_blocks, block_size]`. The
+prefix tells you the layout. For MXFP4:
+
+| Tensor | Blocks shape | Prefix = dense shape |
+|--------|-------------|---------------------|
+| `gate_up_proj_blocks` | `[E, 2*inter, G, 16]` | `[E, 2*inter, hidden]` = `[E, out, in]` |
+| `down_proj_blocks` | `[E, hidden, G, 16]` | `[E, hidden, inter]` = `[E, out, in]` |
+
+Both happen to match our runtime `[E, out, in]` layout — no transpose
+needed inside `hf2dcp`. The transpose only happens at `dcp2hf` (to
+produce HF's live `[E, in, out]` BF16 layout).
+
+### Step 3 — Write the dequant function
+
+Adapt from:
+
+- Megatron-Bridge (https://github.com/NVIDIA/Megatron-Bridge)
+- HuggingFace Transformers `src/transformers/quantizers/<format>.py`
+- The model's release repo (OpenAI, Qwen, etc.)
+- TorchTitan if it has a reference
+
+See `_dequantize_mxfp4` in `pithtrain/tasks/convert_checkpoint.py` for
+the MXFP4 reference.
+
+### Step 4 — Verify against HF's live dequant
+
+Don't just test norms — test element-wise:
+
+```python
+from transformers import AutoModelForCausalLM
+import torch
+
+# HF's own BF16 dequant of the SAME MXFP4 checkpoint
+hf = AutoModelForCausalLM.from_pretrained("<hf_id>", dtype=torch.bfloat16)
+hf_live = hf.state_dict()
+
+# One expert slice from our DCP conversion
+ours_e0_gate = dcp_state_dict["layers.0.mlp.experts.0.gate_up_proj"]  # [2*inter, hidden]
+hf_gate_up   = hf_live["model.layers.0.mlp.experts.gate_up_proj"]     # [E, in, out] = [E, hidden, 2*inter]
+
+# HF's stored as [E, in, out]; our stored as [out, in].  Transpose for comparison.
+ours_hf_shape = ours_e0_gate.transpose(-2, -1)   # → [hidden, 2*inter]
+theirs = hf_gate_up[0]
+
+print("norm ours:", ours_hf_shape.float().norm().item())
+print("norm theirs:", theirs.float().norm().item())
+print("max_abs_diff:", (ours_hf_shape.float() - theirs.float()).abs().max().item())
+```
+
+Norms matching but element-wise differing means you have a
+transpose / interleave bug. **Norms are invariant under transposition;
+norm-only checks miss the whole class of layout bugs.**
+
+## `hf2dcp` structure
+
+```python
+def _hf2dcp_<model>(load_path: Path, save_path: Path, stdout: Logger) -> None:
+    # 1. Load raw safetensors into a dict on CPU
+    with open(load_path / "model.safetensors.index.json") as f:
+        weight_map = json.load(f)["weight_map"]
+    raw: Dict[str, torch.Tensor] = {}
+    for shard in sorted(set(weight_map.values())):
+        with safe_open(str(load_path / shard), framework="pt", device="cpu") as f:
+            for key in f.keys():
+                raw[key] = f.get_tensor(key)
+
+    # 2. Dequantize quant_type-specific tensors (adjust for your format)
+    dequantized: Dict[str, torch.Tensor] = {}
+    seen = set()
+    for key in sorted(raw.keys()):
+        if key.endswith("_blocks"):
+            base = key.removesuffix("_blocks")
+            scales_key = base + "_scales"
+            if scales_key in raw:
+                dequantized[base] = _dequantize_<format>(raw[key], raw[scales_key]).contiguous()
+                seen.add(key); seen.add(scales_key)
+
+    for key, tensor in raw.items():
+        if key not in seen and key not in dequantized:
+            dequantized[key] = tensor
+
+    # 3. Split stacked expert tensors into per-expert indexed keys,
+    # strip "model." prefix, leave everything else alone.
+    model_state_dict: Dict[str, torch.Tensor] = {}
+    for key, tensor in dequantized.items():
+        canon = key.removeprefix("model.")
+
+        if canon.endswith((
+            ".mlp.experts.gate_up_proj",
+            ".mlp.experts.gate_up_proj_bias",
+            ".mlp.experts.down_proj",
+            ".mlp.experts.down_proj_bias",
+        )):
+            for idx in range(tensor.shape[0]):
+                expert_key = canon.replace(".experts.", f".experts.{idx}.")
+                model_state_dict[expert_key] = tensor[idx].contiguous()
+        else:
+            model_state_dict[canon] = tensor
+
+    # 4. Write DCP
+    save_path.mkdir(parents=True, exist_ok=True)
+    dcp.save({"app": {"model": model_state_dict}}, checkpoint_id=save_path, no_dist=True)
+```
+
+Register the branch in the top-level `hf2dcp` via an `_is_<model>` probe
+that reads `load_path/config.json` and checks `model_type`.
+
+## `dcp2hf` structure
+
+The generic path stacks per-expert keys and adds `model.` prefix. What
+a model-specific branch adds is the **layout transpose** from our
+`[E, out, in]` storage to HF's live `[E, in, out]`.
+
+Extend `_stack_experts` with a model-aware gate:
+
+```python
+def _stack_experts(state_dict, stdout):
+    _WEIGHT_KEYS = (".mlp.experts.gate_up_proj", ".mlp.experts.down_proj")
+    # per-expert indexed → stacked
+    ...
+    for stacked_canon, by_idx in to_stack.items():
+        items = sorted(by_idx.items())
+        stacked = torch.stack([t for _, t in items])       # [E, out, in]
+        if stacked_canon.endswith(_WEIGHT_KEYS):
+            stacked = stacked.transpose(-2, -1).contiguous()   # → [E, in, out]
+        result[stacked_canon] = stacked
+    return result
+```
+
+The `_is_<model>_dcp(metadata)` probe decides whether to call
+`_stack_experts` — e.g. `_is_gpt_oss_dcp` checks for `gate_up_proj`
+keys in the metadata. For non-quantized models (Qwen3, DeepSeek-V2),
+`_is_<model>_dcp` returns False and the generic path writes the DCP
+as-is.
+
+## The round-trip validation
+
+This is the only check that catches every class of bug.
+
+### Step 1 — Round-trip
+
+```bash
+# Config: hf → dcp → hf
+python -c "
+from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg, launch
+from pathlib import Path
+
+cfg = ConvertCheckpointCfg()
+cfg.operation = 'hf2dcp'
+cfg.load_path = Path('<hf_snapshot>')
+cfg.save_path = Path('<dcp_dir>')
+launch(cfg)
+
+cfg = ConvertCheckpointCfg()
+cfg.operation = 'dcp2hf'
+cfg.load_path = Path('<dcp_dir>')
+cfg.save_path = Path('<bf16_snapshot>')
+launch(cfg)
+"
+```
+
+### Step 2 — Strip `quantization_config`
+
+Our `dcp2hf` writes BF16 safetensors but inherits `config.json` from
+the source. If the source is quantized, its `quantization_config` block
+tells transformers to expect quantized tensors — and the load fails.
+Strip it:
+
+```python
+import json
+from pathlib import Path
+
+snap = Path("<bf16_snapshot>")
+cfg = json.loads((snap / "config.json").read_text())
+cfg.pop("quantization_config", None)
+cfg["torch_dtype"] = "bfloat16"
+(snap / "config.json").write_text(json.dumps(cfg, indent=2))
+```
+
+### Step 3 — Load and compare
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+
+# Our round-tripped BF16
+ours = AutoModelForCausalLM.from_pretrained("<bf16_snapshot>", dtype=torch.bfloat16)
+# HF's own BF16 dequant of the ORIGINAL quantized snapshot
+theirs = AutoModelForCausalLM.from_pretrained("<hf_snapshot>", dtype=torch.bfloat16)
+
+our_sd = ours.state_dict()
+their_sd = theirs.state_dict()
+
+assert set(our_sd.keys()) == set(their_sd.keys()), (
+    set(our_sd.keys()) ^ set(their_sd.keys())
+)
+
+max_diff = 0.0
+for k in sorted(our_sd.keys()):
+    d = (our_sd[k].float() - their_sd[k].float()).abs().max().item()
+    if d > max_diff:
+        max_diff = d
+        print(f"new worst: {k} diff={d:.4e}")
+print(f"overall max_abs_diff = {max_diff:.4e}")
+```
+
+**Goal: `max_abs_diff == 0` across all keys.** If it's nonzero, bisect
+by key prefix (`embed_tokens.*`, `layers.0.self_attn.*`, `layers.0.mlp.experts.*`, etc.)
+and find the first class of tensor that differs.
+
+## Launch scripts
+
+Add `examples/convert_checkpoint/<model>/script.py`:
+
+```python
+from pathlib import Path
+from huggingface_hub import snapshot_download
+from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg, launch
+
+cfg = ConvertCheckpointCfg()
+cfg.operation = "hf2dcp"
+cfg.load_path = Path("workspace/checkpoints/<model>/hf-import")
+cfg.save_path = Path("workspace/checkpoints/<model>/torch-dcp/step-00000000")
+
+if __name__ == "__main__":
+    snapshot_download(repo_id="<hf-id>", local_dir=cfg.load_path)
+    launch(cfg)
+
+cfg = ConvertCheckpointCfg()
+cfg.operation = "dcp2hf"
+cfg.load_path = Path("workspace/checkpoints/<model>/torch-dcp/step-00000000")
+cfg.save_path = Path("workspace/checkpoints/<model>/hf-export")
+
+if __name__ == "__main__":
+    launch(cfg)
+```
+
+## Memory: load canonical to CPU
+
+`_load_dcp_canonical` reads every weight into one dict. A 20B-class
+model is ~42 GB; 120B is ~218–234 GB. If `torch.set_default_device("cuda")`
+is set, that whole canonical dict lands on GPU and OOMs before the
+model even builds.
+
+**Always** allocate the canonical on CPU (`device="cpu"` in the
+`torch.empty` that backs DCP's read), filter to this rank's keys, then
+`.to(device)` only the filtered result. See
+`tests/test_gpt_oss_inference.py:_load_dcp_canonical` for the pattern.
+
+## Checklist
+
+- [ ] `print(tensor.shape, tensor.dtype)` for every key in one shard —
+      don't trust comments.
+- [ ] Dequant function adapted from a reference impl; tested on one
+      weight against HF's live dequant.
+- [ ] `hf2dcp` splits stacked expert tensors into per-expert indexed
+      keys; nothing else renamed.
+- [ ] `dcp2hf` (or `_stack_experts`) stacks back, transposes 3-D
+      weights, adds `model.` prefix.
+- [ ] Round-trip: strip `quantization_config` from output config,
+      element-wise compare to HF's BF16 dequant, `max_abs_diff == 0`.
+- [ ] `_load_dcp_canonical` allocates on CPU.

--- a/.claude/skills/add-new-model/reference/compile.md
+++ b/.claude/skills/add-new-model/reference/compile.md
@@ -1,0 +1,247 @@
+# `@torch.compile(fullgraph=True)` — The Three Hot Regions
+
+Three per-layer regions must be wrapped with
+`@torch.compile(fullgraph=True)`:
+
+1. `_forward_attn_compute` — LN + attention + LN (+ shared experts if any)
+2. `router.compute` / `gate.compute` — top-k + softmax + load-balance injection
+3. `forward_aggregate` — weighted expert sum + residual add
+
+These are not recommendations. They are enforced by the framework: test
+failures and performance regressions have previously traced back to
+missing or weakened compile coverage on these regions.
+
+## Why `fullgraph=True` specifically
+
+`fullgraph=True` *forces* Dynamo to raise on any would-be graph break.
+`fullgraph=False` is strictly worse for this codebase:
+
+- **Compile boundaries accumulate bf16 rounding drift.** Each sub-graph
+  gets its own compile; crossing back and forth adds rounding that the
+  single-shot fullgraph trace avoids.
+- **Cross-region fusion is missed.** The LN → matmul fusion, the
+  weighted-sum + residual fusion, etc., happen *because* the whole region
+  is one graph.
+- **Breakage is hidden.** Without `fullgraph=True` you don't learn that
+  a new attention kernel silently self-compiles until a microbench
+  shows the speedup is gone.
+
+**Never reach for `fullgraph=False` as a workaround.** If a region can't
+compile fullgraph, unwrap the region entirely (see below) and treat the
+unwrap as tech debt.
+
+## The three regions — boilerplate
+
+### Region 1: `_forward_attn_compute`
+
+```python
+@torch.compile(fullgraph=True)
+def _forward_attn_compute(self, hidden_states):
+    residual = hidden_states
+    hidden_states = self.input_layernorm(hidden_states)
+    hidden_states = self.self_attn(hidden_states, position_embeddings=..., ...)
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = self.post_attention_layernorm(hidden_states)
+
+    # Shared experts fold into residual here, before returning.
+    if hasattr(self.mlp, "shared_experts"):
+        residual = residual + self.mlp.shared_experts(hidden_states)
+
+    return hidden_states, residual
+```
+
+### Region 2: router / gate `compute`
+
+```python
+class <Prefix>TopKRouter(nn.Module):   # or <Prefix>Gate — match HF
+    @torch.compile(fullgraph=True)
+    def compute(self, hidden_states):
+        batch_size, seq_len, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_size)
+
+        logits = F.linear(hidden_states, self.weight, self.bias)  # bias optional
+        topk_logits, topk_idx = torch.topk(logits, k=self.num_experts_per_tok, dim=-1, sorted=True)
+        topk_weight = F.softmax(topk_logits, dim=-1, dtype=torch.float32)
+
+        if self.training and self.load_balance_loss_fn is not None:
+            scores = logits.softmax(dim=-1, dtype=torch.float32)
+            lb_loss = self.load_balance_loss_fn(
+                scores, topk_idx, self.num_experts, self.num_experts_per_tok,
+            )
+            topk_weight = MoELoadBalanceLossInjector.apply(topk_weight, lb_loss)
+        else:
+            lb_loss = None
+
+        return topk_idx, topk_weight, lb_loss
+
+    def forward(self, hidden_states):
+        topk_idx, topk_weight, lb_loss = self.compute(hidden_states)
+        if lb_loss is not None:
+            MoELoadBalanceLossTracker.add(lb_loss)
+        return topk_idx, topk_weight
+```
+
+### Region 3: `forward_aggregate`
+
+```python
+@torch.compile(fullgraph=True)
+def forward_aggregate(self, moe_outs, moe_local_idxs, topk_weight, residual):
+    # ... weighted sum branches — see protocol.md ...
+    return residual + hidden_states
+```
+
+## When you MUST unwrap — the attention kernel problem
+
+Some attention kernels compile themselves:
+- `flex_attention` (always, when called)
+- Ring attention with internal `torch.compile`
+
+Nested compile fails: `torch._dynamo.exc.Unsupported: compile-inside-compile`.
+
+### Narrow, conditional unwrap (the pattern)
+
+Unwrap **only when the incompatible kernel is active**. Qwen3 and
+DeepSeek-V2 handle ring attention this way:
+
+```python
+class <Prefix>DecoderLayer(nn.Module):
+    def __init__(self, ...):
+        super().__init__()
+        # ... build sub-modules ...
+
+        # Unwrap only if the incompatible attention kernel is selected.
+        if self.self_attn.use_ring_attn:
+            self._forward_attn_compute = self._forward_attn_compute.__wrapped__.__get__(
+                self, type(self),
+            )
+```
+
+Two reasons this is narrow:
+
+1. Most runs don't hit the unwrap (context parallel is off).
+2. The gate should depend on the *kernel selection*, not on a blanket
+   "always unwrap because flex is sometimes used" — that loses the
+   compile benefit for configurations that could have it.
+
+Similarly, `setup_model` in `pithtrain/modules/training.py` unwraps the
+gate's `compute` when CP is on, because the all-reduce injected by the
+global-batch load balance loss breaks fullgraph tracing:
+
+```python
+if cp_group is not None:
+    gate.compute = gate.compute.__wrapped__.__get__(gate, type(gate))
+```
+
+### The `__wrapped__.__get__` idiom
+
+`@torch.compile` replaces the method with a wrapped object. The original
+function is at `.__wrapped__`. Re-binding it to the instance is done
+with `.__get__(self, type(self))`. After the unwrap, calling
+`self._forward_attn_compute(x)` runs the eager Python body.
+
+### Don't unwrap unconditionally
+
+A blanket unwrap breaks performance for all configurations, not just
+the one with the problematic kernel. If the unwrap covers 100% of the
+attention compute, you've lost ~10–30% step-time at short context and
+~5–15% at long context. Treat every unwrap as tech debt; record a brief
+in `docs/` describing what would let us re-land the compile (e.g.
+"upstream flex_attention fix for nested compile").
+
+## The attention-sinks / learned-bias-in-closure problem
+
+If your attention needs a learned parameter inside the softmax (GPT-OSS
+attention sinks, some ALiBi variants), **do not** use a `score_mod`
+closure that captures the Parameter. The closure specialises the kernel's
+self-compile on the Parameter, and that specialisation is what forces
+our outer `fullgraph=True` to unwrap.
+
+### The LSE-renormalisation pattern
+
+Move the Parameter out of the closure and apply its effect as a pure
+post-op. For sinks:
+
+```python
+# Do NOT do this: closure over self.sinks forces nested compile.
+# def score_mod(score, b, h, q, kv): return torch.where(kv == seq_len, self.sinks[h], score)
+# attn_output = flex_attention(q, k, v, score_mod=score_mod, ...)
+
+# Do this instead: return the LSE and renorm as a pointwise post-op.
+attn_output, aux = flex_attention(
+    q, k, v,
+    block_mask=block_mask,
+    scale=self.scaling,
+    enable_gqa=True,
+    return_aux=AuxRequest(lse=True),
+)
+lse = aux.lse
+# softmax([scores, sink])_i = softmax(scores)_i * sigmoid(lse − sink)
+sink_scale = torch.sigmoid(lse - self.sinks.float().view(1, -1, 1))
+attn_output = attn_output * sink_scale.to(attn_output.dtype).unsqueeze(-1)
+```
+
+This is mathematically identical to including a virtual KV row at
+`v = 0` with per-head score `self.sinks[h]`. The sink doesn't
+contribute to the numerator (it has `v = 0`), only to the denominator
+(the `exp(sinks[h])` term). The `sigmoid(lse - sinks)` factor folds that
+denominator change into the output.
+
+**Before writing the refactor yourself, check upstream.** HuggingFace
+Transformers and TorchTitan have both converged on this pattern for
+GPT-OSS independently. HF's `integrations/flex_attention.py` has the
+literal comment that score_mod cannot implement sinks correctly.
+
+## Inference-time compile (the seq-len-grows problem)
+
+At training time, seq_len is constant → one compile total.
+
+At **autoregressive inference**, seq_len grows by 1 every step. If the
+test harness passes the current `[batch, prompt_len + step, hidden]`
+tensor to `_forward_attn_compute`, Dynamo retraces every step. With
+flex_attention inside, each retrace can take tens of seconds.
+
+### Do NOT fix this by weakening the model's compile
+
+Don't add `dynamic=True` to the model's `@torch.compile` decorator. The
+modeling code must stay identical to what training uses — see
+`feedback_modeling_code_matches_training`. An inference-only compile
+flag on production code means tests stop exercising the training path.
+
+### Fix it in the test harness with static-seq-len decode
+
+Allocate a `[batch, prompt_len + max_new_tokens]` buffer up front, fill
+initial prompt tokens, advance a cursor each step, and always pass the
+full-size buffer through the model:
+
+```python
+max_seq_len = prompt_len + max_new_tokens
+buffer = torch.full((batch, max_seq_len), pad_id, dtype=torch.long, device=device)
+for i, t in enumerate(encoded_prompts):
+    buffer[i, :prompt_len] = t[:prompt_len].to(device)
+cursor = prompt_len
+set_p2p_tensor_shapes([(1, max_seq_len, hidden_size)])   # ONCE, outside the loop
+
+for step in range(max_new_tokens):
+    loss, outputs = dualpipev.step(buffer if ctx.pp_rank == 0 else None, ...)
+    next_tok = outputs[:, cursor - 1, :].float().argmax(dim=-1)   # logit at last real pos
+    buffer[:, cursor] = next_tok
+    cursor += 1
+```
+
+Forward cost per step is higher (you always process `max_seq_len`
+positions), but you trade O(max_new_tokens) compiles for one. In
+practice this cuts a multi-minute test to tens of seconds.
+
+See `templates/inference_test.py` for the full harness.
+
+## Debugging checklist
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `Unsupported: compile-inside-compile` | Nested `@torch.compile` — unwrap outer region *conditionally* on the kernel that self-compiles |
+| Inference wall-clock balloons after first few tokens | Per-seq-len retrace — fix with static-seq-len decode, not `dynamic=True` |
+| Graph breaks reported at each step | `fullgraph=False` is silently catching them — switch to `fullgraph=True` and fix |
+| Step time 30% slower than an earlier branch | Someone removed a `@torch.compile` — check the three hot regions |
+| `calc_diff` passes but worst bias grad looks wrong | Compile drift on small-magnitude params — see `testing.md` on label scaling |

--- a/.claude/skills/add-new-model/reference/conventions.md
+++ b/.claude/skills/add-new-model/reference/conventions.md
@@ -1,0 +1,407 @@
+# Naming, Layout, and Key Conventions
+
+These rules exist because we violated them for a past model and paid the
+cost in silent bugs and asymmetric converters. **Apply them on every new
+model.** The one-sentence summary:
+
+- **Names and structure**: match HuggingFace exactly.
+- **In-memory tensor layout (axis order)**: follow the training-framework
+  consensus (TorchTitan + Megatron-LM / TransformerEngine).
+- **Canonical keys**: per-expert indexed, no rename from HF, transpose
+  only at the `dcp2hf` safetensors boundary.
+- **Config values**: thread per-checkpoint knobs through `__init__`;
+  only architectural constants stay as literals.
+- **Example config**: mirror the upstream shipped `config.json`
+  field-by-field, including nested blocks.
+
+## Rule 1 — Mirror HF's names and structure
+
+This has zero performance implication. There is no reason to deviate.
+
+### Class names
+
+Grep HF's `modeling_<model>.py` for `^class ` and use the same spelling:
+
+```bash
+# Look in the project's venv
+grep "^class " .venv/lib/python*/site-packages/transformers/models/<model>/modeling_<model>.py
+```
+
+Typical mapping:
+
+| HF class | Our class (example) |
+|----------|---------------------|
+| `<Prefix>Attention` | `<Prefix>Attention` |
+| `<Prefix>MLP` (the MoE block) | `<Prefix>MLP` |
+| `<Prefix>Experts` | `<Prefix>Experts` |
+| `<Prefix>TopKRouter` or `<Prefix>Gate` | **exactly** what HF uses |
+| `<Prefix>RotaryEmbedding` | `<Prefix>RotaryEmbedding` (even if YaRN internally) |
+| `<Prefix>DecoderLayer` | `<Prefix>DecoderLayer` |
+
+**Counter-example (do not do this):** GPT-OSS originally named the class
+`GptOssGate` and the attribute `self.mlp.gate`. HF calls them
+`GptOssTopKRouter` and `self.mlp.router`. That mismatch required an
+asymmetric `hf2dcp` (rename `router → gate`) and broke `dcp2hf`
+round-trip. Fix landed later — but only because the original choice
+ignored HF.
+
+### Attribute names
+
+Grep HF's `__init__` for `self.<x> = ...`:
+
+```bash
+grep -n "self\.[a-zA-Z_][a-zA-Z0-9_]*\s*=" \
+    .venv/lib/python*/site-packages/transformers/models/<model>/modeling_<model>.py | head -50
+```
+
+The names of submodules become part of the `state_dict` keys. If HF
+says `self.router`, the state_dict will have
+`layers.0.mlp.router.weight`, and you must match exactly or
+`load_state_dict(strict=False)` silently drops the weight.
+
+### Activation math — don't trust `hidden_act` <a id="activation-math"></a>
+
+The `config.hidden_act` string is shorthand, not a spec. A config that
+says `"silu"` can be hiding:
+
+- `gate * sigmoid(alpha * gate)` with a non-unit `alpha` (the sigmoid
+  approximation of GELU from Hendrycks & Gimpel is `alpha ≈ 1.702`,
+  *not* 1.0 — plain SiLU is only recovered at `alpha = 1`).
+- A clamp on gate or up before the multiply.
+- A bias add inside the expert MLP, before or after the activation.
+- An `(up + 1) * glu`-style residual inside the MLP.
+
+All of these must be copied verbatim. A single wrong constant in the
+activation trains silently to a higher loss without crashing anything —
+it passes phase 3 and phase 4 on random weights, and only surfaces as
+gibberish or poor loss when real pretrained weights are loaded.
+
+**Rule:** don't rely on `hidden_act`. Open HF's `<Prefix>MLP.forward`
+(and the expert MLP if different) and copy the exact math — coefficients,
+clamps, bias adds, residual shapes — into your implementation.
+
+### Fused vs split tensors
+
+If HF stores gate and up as **one fused** tensor `gate_up_proj`, our
+model must also have a single `gate_up_proj` parameter. Don't split
+into `gate_proj` + `up_proj` — that forces a split+deinterleave in
+`hf2dcp` and a re-interleave+merge in `dcp2hf` with high bug risk.
+
+Split the output *at forward time* if you need different post-ops:
+
+```python
+gate_up = F.grouped_mm(x, self.gate_up_proj.transpose(-2, -1), offs=offs)
+gate = gate_up[:, ::2]   # interleaved
+up   = gate_up[:, 1::2]
+```
+
+### `.weight` suffix: submodule vs raw Parameter
+
+- `nn.Linear` / `nn.Embedding` / `GroupLinear` → state_dict key ends in
+  `.weight`.
+- Raw `nn.Parameter` stored on the module itself → state_dict key is
+  just the attribute name, NO `.weight`.
+
+GPT-OSS uses raw `nn.Parameter` for experts to get direct control over
+the `[E, out, in]` storage layout:
+
+```python
+class GptOssExperts(nn.Module):
+    def __init__(self, num_experts, hidden_size, intermediate_size):
+        super().__init__()
+        # These become state_dict keys WITHOUT a .weight suffix:
+        self.gate_up_proj = nn.Parameter(torch.empty(num_experts, 2*intermediate_size, hidden_size))
+        self.gate_up_proj_bias = nn.Parameter(torch.zeros(num_experts, 2*intermediate_size))
+```
+
+State_dict keys look like `layers.0.mlp.experts.gate_up_proj` — no
+`.weight`. Your canonical-key convention (below) must match exactly.
+
+## Rule 2 — Expert weight layout: training-framework consensus
+
+For a given model, check what storage layout the mainstream training
+frameworks use *for that model*, and follow them:
+
+```bash
+# TorchTitan reference (if it exists for this model)
+# github.com/pytorch/torchtitan/blob/main/torchtitan/models/<model>/...
+
+# TransformerEngine GroupedLinear
+# github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/module/grouped_linear.py
+```
+
+Both have converged on `[E, out, in]` with a `.transpose(-2, -1)` view
+at the `F.grouped_mm` call site:
+
+```python
+# Storage
+self.gate_up_proj = nn.Parameter(torch.empty(E, 2*intermediate, hidden))   # [E, out, in]
+# Forward
+out = F.grouped_mm(x, self.gate_up_proj.transpose(-2, -1), offs=offs)      # transposed view
+```
+
+Both `GroupLinear` (in `pithtrain/layers/group_linear.py`) and this
+raw-Parameter pattern match that convention.
+
+HF's live Parameter is often `[E, in, out]` — the transposed layout —
+because HF loads for `F.linear`-style usage. That's fine; the transpose
+between `[E, out, in]` (runtime/DCP) and `[E, in, out]` (HF BF16
+safetensors) lives in **exactly one place**: `_stack_experts` in
+`dcp2hf`. See `checkpoint.md`.
+
+**Do not pick a different layout without evidence** (a microbench showing
+materially faster kernels on our target hardware). In the absence of
+evidence, deviating from the consensus is strictly worse: kernel authors
+tune for it, and quantized paths (MXFP4, FP8) are usually pre-packed in
+the consensus layout.
+
+### Verifying layout correctness after conversion
+
+Norms are invariant under transposition. A norm match does NOT prove
+the layout is right. The real check is element-wise:
+
+```python
+# After hf2dcp → dcp2hf → transformers.AutoModelForCausalLM.from_pretrained:
+rt_state = round_tripped_model.state_dict()
+hf_state = hf_model.state_dict()           # load the original HF model fresh
+
+for k in hf_state:
+    ours = rt_state[k].float()
+    theirs = hf_state[k].float()
+    assert ours.shape == theirs.shape, (k, ours.shape, theirs.shape)
+    diff = (ours - theirs).abs().max().item()
+    assert diff == 0, (k, diff)             # byte-identical is the goal
+```
+
+If norms match but element-wise differs, you have a transpose bug
+(`.view()` instead of `.transpose()` — see `pitfalls.md`).
+
+## Rule 3 — Canonical DCP keys
+
+The DCP checkpoint format is our internal standard. It differs from HF
+in exactly two ways:
+
+1. **Per-expert indexed keys.** HF stacks all experts into one 3-D
+   tensor:
+   ```
+   HF:     model.layers.0.mlp.experts.gate_up_proj           shape [E, ...]
+   Ours:   layers.0.mlp.experts.0.gate_up_proj               shape [...]
+           layers.0.mlp.experts.1.gate_up_proj
+           ...
+           layers.0.mlp.experts.E-1.gate_up_proj
+   ```
+   This lets us filter by EP rank cleanly: rank `r` loads experts
+   `[r*per_rank, (r+1)*per_rank)` without re-slicing a huge tensor.
+
+2. **No `model.` prefix.** HF's state_dict keys start with `model.` for
+   everything except `lm_head`. Ours drops that prefix in the canonical
+   keys and reintroduces it in `dcp2hf`.
+
+Nothing else should differ. In particular:
+
+- **No renaming.** If HF uses `router`, our canonical key uses `router`.
+  Do not rename to `gate` in `hf2dcp` and back in `dcp2hf` — the
+  asymmetry is bug-prone and our *model code* should already use
+  `router` (see Rule 1).
+- **No shape transforms beyond the layout transpose at dcp2hf.**
+
+### Converter responsibilities
+
+- `hf2dcp`: `model.layers.0.mlp.experts.gate_up_proj [E, out, in]`
+  → split along dim 0 into E per-expert tensors (each `[out, in]`)
+  → write under `layers.0.mlp.experts.IDX.gate_up_proj`.
+  (Dequant if needed — see `checkpoint.md`.)
+- `dcp2hf`: `_stack_experts` stacks per-expert tensors back into
+  `[E, out, in]`, transposes to `[E, in, out]` for HF live layout,
+  adds `model.` prefix, writes safetensors.
+
+### Round-trip test (non-negotiable)
+
+Do this immediately after writing both directions:
+
+```bash
+hf2dcp <hf_snapshot> <dcp_dir>
+dcp2hf <dcp_dir> <bf16_snapshot>
+# strip quantization_config from bf16_snapshot/config.json first
+python -c "
+from transformers import AutoModelForCausalLM
+m = AutoModelForCausalLM.from_pretrained('<bf16_snapshot>', dtype='bfloat16')
+# compare m.state_dict() against HF's own BF16 dequant of the original
+"
+```
+
+See `checkpoint.md` for the full round-trip validation recipe.
+
+## Rule 4 — Thread config values through `__init__` <a id="thread-config"></a>
+
+Any value that appears in HF's `config.json` for the model is a
+**per-checkpoint knob**, not an architectural constant — even if every
+released checkpoint currently ships the same value. Thread it through
+the model init from the config, don't hardcode it as a module-level
+literal. Future fine-tunes / derivative releases can and do change
+these fields.
+
+### Diff check
+
+Diff the shipped `config.json` against every numeric (and string)
+literal in your modeling file. If a literal equals a config field, read
+it from the config. If it doesn't, leave a one-line comment naming the
+source (paper, reference impl) so the reader knows why it's hardcoded.
+
+```python
+# Per-checkpoint knob — threaded from config:
+#   Model(config) → DecoderLayer(...) → MLP(...) → Experts(..., swiglu_limit=config.swiglu_limit)
+def __init__(self, ..., swiglu_limit: float):
+    ...
+    self.swiglu_limit = swiglu_limit
+
+# Architectural constant — hardcoded, with a one-line source comment:
+SWIGLU_ALPHA = 1.702  # sigmoid approximation of GELU (Hendrycks & Gimpel 2016).
+```
+
+Decision rule:
+
+| Is it in `config.json`? | Is it in `<Model>Config.__init__` signature? | Treat as |
+|-------------------------|---------------------------------------------|----------|
+| Yes | Yes | Per-checkpoint knob — thread through `__init__` |
+| No | Yes (optional arg with default) | Per-checkpoint knob — thread through `__init__` |
+| No | No | Architectural constant — module literal with source comment |
+
+### Why this matters
+
+"We'll fix it when someone ships a different value" is false economy.
+A hardcoded knob breaks silently when a derivative release changes it —
+no AttributeError, no shape mismatch, just a higher loss than expected
+that only surfaces weeks later in training runs that are hard to bisect.
+
+## Rule 5 — Example configs mirror upstream HF, field-by-field <a id="example-config"></a>
+
+When adding `examples/pretrain_language_model/<model>/config.json`, it
+must match the upstream HuggingFace `config.json` on every
+semantically-meaningful knob — especially the nested blocks
+(`rope_scaling`, `quantization_config`, any `*_parameters` dicts, etc.).
+A missing field defaults to our code's fallback, which may differ from
+HF's fallback, and then weights loaded from the released checkpoint
+compute against subtly different numerics.
+
+### The field-by-field diff
+
+```bash
+python -c "
+import json
+hf   = json.load(open('<hf_snapshot>/config.json'))
+ours = json.load(open('examples/pretrain_language_model/<model>/config.json'))
+for k in sorted(set(hf) | set(ours)):
+    if hf.get(k) != ours.get(k):
+        print(k, 'HF=', hf.get(k), 'ours=', ours.get(k))
+"
+```
+
+For any deliberate divergence, leave a one-line comment in the model
+code explaining why. "We didn't know about this field" is the most
+common cause of a loaded checkpoint's initial loss being in the wrong
+order of magnitude.
+
+### The three sources of config defaults
+
+"Matches the HF config" is not one check, it's three:
+
+1. **The shipped `config.json`** on the HuggingFace Hub — the released
+   artifact's view of the model.
+2. **The `<Model>Config.__init__` signature** in
+   `transformers/models/<model>/configuration_<model>.py` — the
+   defaults HF uses when a field is *absent* from the config.json, and
+   when users construct the config programmatically.
+3. **The generic fallback path** the modeling code reads through (e.g.
+   `modeling_rope_utils.py::_compute_yarn_parameters` does
+   `rope_parameters.get("truncate", True)`) — what happens when the
+   value isn't in either of the above.
+
+These three can disagree. When they do, defaults for a
+**model-specific** class should match the **model-specific** HF default
+(source 2), not the generic fallback (source 3). If the modeling code
+is generic, match the generic fallback.
+
+### Concrete example — rotary embedding with a YaRN-style `truncate` flag
+
+Some YaRN-style rotary implementations expose a `truncate` flag on
+whether to `math.floor`/`math.ceil` the correction-range bounds.
+
+- Shipped `config.json` explicitly sets `rope_scaling.truncate = false`.
+- `<Model>Config.__init__` hardcodes `rope_parameters = {..., "truncate": False, ...}`.
+- Generic `_compute_yarn_parameters` falls back to `.get("truncate", True)`.
+
+A faithful port:
+
+- The modeling class defaults `truncate=False` (match source 2), so
+  programmatic construction matches the published config.
+- The example `config.json` carries `rope_scaling.truncate: false`
+  explicitly (match source 1), so a loaded config never relies on the
+  fallback.
+- Correction-range helpers take `truncate` as a parameter and only
+  round when it's `True`:
+  ```python
+  def _yarn_find_correction_range(low_rot, high_rot, dim, base, mpe, truncate):
+      low  = _yarn_find_correction_dim(low_rot,  dim, base, mpe)
+      high = _yarn_find_correction_dim(high_rot, dim, base, mpe)
+      if truncate:
+          low, high = math.floor(low), math.ceil(high)
+      return max(low, 0), min(high, dim - 1)
+  ```
+
+A hardcoded `math.floor` / `math.ceil` is a correctness bug for any
+model that ships `truncate=false` — rotary positions drift from the
+trained checkpoint's and CE lands in the wrong order of magnitude.
+
+### Concrete checklist for a new model
+
+- [ ] Diff the shipped Hub `config.json` against your example
+      `config.json` field-by-field — including every nested block.
+- [ ] Open `transformers/models/<model>/configuration_<model>.py` and
+      read every default in `__init__`. For every default that differs
+      from the generic path the modeling code takes, note which opinion
+      you're matching and why.
+- [ ] For any layered-default field (rope, dropout, init ranges,
+      routing coefficients), make sure the default on your class *and*
+      the fallback in any config-reader code are both the model-specific
+      opinion. They should not disagree with each other.
+- [ ] Sanity-check by constructing your model without any config.json
+      (pure programmatic path) and confirm numerics match what HF's
+      equivalent programmatic construction would produce.
+
+## Summary table
+
+| Aspect | Follow | Failure mode if ignored |
+|--------|--------|------------------------|
+| Class names | HF exactly | Reader confusion, bring-up slowdown |
+| Attribute names | HF exactly | state_dict key mismatch, silent zero loading |
+| Fused vs split tensors | HF exactly | Bug-prone split/merge in converter |
+| `.weight` suffix | Match model's actual state_dict() output | Missing keys, silent random init |
+| Activation math | Read HF's MLP forward verbatim | Silently higher training loss |
+| Per-checkpoint knobs | Thread through `__init__` from config | Derivative checkpoints break silently |
+| Example `config.json` | Mirror upstream HF field-by-field, nested blocks included | Rotary / numerics drift vs trained weights |
+| Class `__init__` defaults | Match model-specific HF `__init__` default, not generic fallback | Programmatic construction disagrees with loaded config |
+| Expert weight in-memory layout | TorchTitan / TE consensus (`[E, out, in]`) | Slower kernels, converter drift |
+| Canonical DCP keys | Per-expert indexed, no rename | Asymmetric converter, round-trip failure |
+| Where the `[E, out, in] ↔ [E, in, out]` transpose lives | Only at `dcp2hf` | Scrambled weights, inference gibberish |
+
+## Quick diagnostic commands
+
+```bash
+# Class name inventory in HF and ours (align them first):
+grep "^class " .venv/lib/python*/site-packages/transformers/models/<model>/modeling_<model>.py
+grep "^class " pithtrain/models/<model>.py
+
+# Attribute name inventory:
+grep -n "self\.[a-zA-Z_][a-zA-Z0-9_]*\s*=" \
+    .venv/lib/python*/site-packages/transformers/models/<model>/modeling_<model>.py | head -50
+
+# Actual safetensors shapes (never trust comments):
+python -c "
+from safetensors import safe_open
+with safe_open('<shard>', framework='pt', device='cpu') as f:
+    for k in sorted(f.keys()):
+        t = f.get_tensor(k)
+        print(k, tuple(t.shape), t.dtype)
+"
+```

--- a/.claude/skills/add-new-model/reference/pitfalls.md
+++ b/.claude/skills/add-new-model/reference/pitfalls.md
@@ -1,0 +1,371 @@
+# Known Pitfalls
+
+Every entry here is a real bug that cost time on a previous
+integration. Read this file proactively — not just after failure. Most
+of these have silent failure modes, so a clean-looking test can hide
+one of them.
+
+## NaN-padding in `F.grouped_mm` (affects any MoE with biased experts)
+
+`scatter_for_grouped_gemm` over-allocates output rows to a multiple of
+`_GEMM_ALLOC_ALIGNMENT = 1024` for caching-allocator efficiency.
+`F.grouped_mm(x, W, offs=...)` writes only rows `[0, offs[-1])`; rows
+beyond that are uninitialised and can come back as NaN.
+
+Without biases, NaN rows get discarded by
+`outs[reverse_shuffle_idxs]` and nothing observable breaks. With
+biases + elementwise activations:
+
+```python
+gate = grouped_mm(x, W_gate) + bias[group_ids]
+glu  = gate * sigmoid(α * gate)           # NaN rows propagate into bias
+up   = grouped_mm(x, W_up) + bias[group_ids]
+activated = (up + 1) * glu
+```
+
+During backward, `0 * NaN = NaN` poisons gradients. The symptom is
+tiny bias gradients (`~2.5e-5` local) vs huge reference gradients
+(`~2.4e+1`) — a 6-order-of-magnitude discrepancy, not bf16 noise.
+
+### Fix
+
+Truncate expert input to `sum(ks)` before the matmul:
+
+```python
+def forward(self, x, grouped_mm_offs, ks=None, ks_tensor=None):
+    if ks is not None:
+        actual_m = sum(ks)
+        if actual_m < x.shape[0]:
+            x = x[:actual_m]
+    # ... now the grouped GEMM only touches valid rows ...
+```
+
+`ks` is a Python list; `sum(ks)` is a cheap Python int. No GPU sync.
+
+## `.view()` vs `.transpose()` — never use `view` to reorder axes
+
+`.view()` reinterprets flat memory in row-major order. It does NOT
+permute axes. `.view(E, B, A)` on a `[E, A, B]` tensor gives you
+scrambled data, not swapped axes.
+
+```python
+# WRONG — scrambles the memory
+flat = _dequantize_mxfp4(blocks, scales)   # [E, out, in]
+# flat.view(E, in, out)                     # <-- this does NOT transpose
+
+# RIGHT — actually swaps the axes
+flat.transpose(-2, -1).contiguous()        # [E, in, out]
+```
+
+### When this bit us
+
+MXFP4 dequant came out as `[E, 2*inter, hidden]`. Original code did
+`.view(E, hidden, 2*inter)` to "match" a guess about HF's layout.
+Every expert weight was scrambled. FSDP gradient tests (which use
+random weights) all passed. Inference produced gibberish. Days lost.
+
+### How to catch it early
+
+After any conversion, compare **element-wise** (not just norms) against
+HF's live tensor:
+
+```python
+diff = (ours - theirs).abs().max().item()
+assert diff == 0
+```
+
+Norms are invariant under transposition. Norm-only checks miss this
+entire bug class.
+
+## Silent-zero experts (fill_weights miss)
+
+When experts are stored as raw `nn.Parameter` on the module itself
+(GPT-OSS pattern — used to control `[E, out, in]` layout directly),
+`tests/test_fsdp.py`'s `fill_weights` doesn't reach them unless there
+is an `isinstance(module, <Model>Experts)` branch. The parameter stays
+at its `torch.empty()` state, which on our system is literally zero
+(not random garbage, not NaN — zero).
+
+### Symptom
+
+- Every MoE layer emits
+  `[warn] Parameter ... has all-zero gradient, skipping`.
+- `mlp(x)` is exactly zero (not "small" — zero).
+- Residual stream passes through unchanged.
+- The test passes trivially because *nothing* is learning.
+
+### Fix
+
+Add a branch in `fill_weights`:
+
+```python
+elif isinstance(module, <Model>Experts):
+    nn.init.xavier_uniform_(module.gate_up_proj, gain=1.0)
+    nn.init.xavier_uniform_(module.down_proj, gain=1.0)
+    # initialise any other raw Parameters on the experts module here
+```
+
+Production training (`pithtrain/modules/training.py::init_weights`)
+doesn't have this bug — it walks `named_parameters()` and dispatches
+by name substring. The FSDP test's `fill_weights` is class-dispatched
+and must be updated per model.
+
+### Diagnostic
+
+If you see "all-zero gradient" warnings for every MoE param in every
+layer, register a forward hook on `layer.mlp` and print its output
+norm. Zero everywhere → you missed fill_weights. Five-minute fix vs
+hours of chasing the wrong lead.
+
+## `shard_experts` fallback misclassifies the router
+
+`shard_experts` in `tests/test_fsdp.py` detects the experts module
+via `GroupLinear` children. When experts are raw `nn.Parameter`, there's
+a fallback. **The fallback must be gated on a distinctive weight name,
+not `num_experts` alone.** The router has `num_experts`,
+`weight.shape[0] == num_experts`, and often `bias.shape[0] == num_experts`
+— all of which would *look* like an experts module to a naive
+fallback.
+
+### What happens if the router gets sharded
+
+Every rank ends up with only `num_experts / ep_size` entries in the
+routing table, so most expert IDs route to a rank that doesn't own
+that expert — routing collapses, outputs become garbage.
+
+### Fix
+
+```python
+# inside shard_experts
+gu = getattr(model, "gate_up_proj", None)
+if isinstance(gu, nn.Parameter):
+    num_experts = getattr(model, "num_experts", None)
+# — the router doesn't have a gate_up_proj, so it's never matched here
+```
+
+Extend the gate condition with your model's distinctive expert-weight
+name if it's not `gate_up_proj`.
+
+## Stage-record copy — skipping stages 2 and 4
+
+`Model.forward` builds a fresh `IntermediateTensorsLayer` and copies
+each stage record into the pre-allocated slot. Stages 1, 3, 5 have
+`.args`, `.ctx`, `.outs`. Stages 2 and 4 have `.ctx` only.
+
+### Wrong
+
+```python
+for field in fields(layer_record):
+    src_rec = getattr(layer_record, field.name)
+    if hasattr(src_rec, 'args'):      # <-- SKIPS STAGE 2 AND STAGE 4
+        for rf in fields(src_rec):
+            setattr(getattr(dst, field.name), rf.name, getattr(src_rec, rf.name))
+```
+
+### Right
+
+```python
+for field in fields(layer_record):
+    src_rec = getattr(layer_record, field.name)
+    dst_rec = getattr(dst, field.name)
+    for rf in fields(src_rec):
+        setattr(dst_rec, rf.name, getattr(src_rec, rf.name))
+```
+
+Iterate **every field of every record** — don't special-case.
+
+### Symptom
+
+Confusing "invalid gradient shape" error in stage 4 backward. The
+all-to-all combine context is missing, so the shape of its gradient
+input doesn't match.
+
+## Left-padding corrupts causal attention on short prompts
+
+When batching variable-length prompts for autoregressive inference, the
+natural thing is to left-pad to the longest. A causal-only model (no
+key_padding_mask) then attends to pad tokens from later positions as if
+they were real context.
+
+### Symptom
+
+In a mixed batch:
+- Long prompts (little or no left-pad) → coherent.
+- Short prompts (heavy left-pad) → gibberish.
+
+Deceptive because some prompts "work" — it looks like an intermittent
+model bug.
+
+### Fix
+
+Trim every prompt to the length of the **shortest**, not left-pad to
+the longest:
+
+```python
+enc = [tokenizer.encode(p, return_tensors="pt").squeeze(0) for p in prompts]
+prompt_len = min(t.shape[0] for t in enc)       # not max
+for i, t in enumerate(enc):
+    buffer[i, :prompt_len] = t[:prompt_len].to(device)
+```
+
+The alternative (implementing a key_padding_mask inside the
+causal/sliding block_mask) is intrusive and may not compose cleanly
+with other mask_mods. Don't reach for it unless you need
+variable-length prompts in production.
+
+## Dynamic seq_len under `fullgraph=True` — don't touch the model
+
+Autoregressive decode grows seq_len by 1 per step. Each new seq_len
+retraces the compiled region, which can cost many seconds per step
+with flex_attention inside.
+
+### DO NOT do
+
+- Set `dynamic=True` on the model's `@torch.compile` decorator.
+- Change the model's compile region to `fullgraph=False`.
+- Remove the decorator "just for inference testing".
+
+All of these break the invariant that the modeling code equals the
+training path. Inference tests must exercise the training code
+verbatim.
+
+### DO do
+
+Static-seq-len decode in the test harness. Allocate a `[batch,
+prompt_len + max_new_tokens]` buffer, fill prompt tokens, advance a
+cursor, always pass the full buffer to the model. Set p2p shapes
+*once* outside the loop:
+
+```python
+max_seq_len = prompt_len + max_new_tokens
+buffer = torch.full((batch, max_seq_len), pad_id, dtype=torch.long, device=device)
+for i, t in enumerate(enc):
+    buffer[i, :prompt_len] = t[:prompt_len].to(device)
+cursor = prompt_len
+set_p2p_tensor_shapes([(1, max_seq_len, hidden_size)])    # once!
+
+for step in range(max_new_tokens):
+    loss, outputs = dualpipev.step(buffer if ctx.pp_rank == 0 else None, ...)
+    next_tok = outputs[:, cursor - 1, :].float().argmax(dim=-1)
+    buffer[:, cursor] = next_tok
+    cursor += 1
+```
+
+Forward cost per step is higher, but you trade
+`O(max_new_tokens)` compiles for one. A multi-minute test becomes tens
+of seconds.
+
+## Load canonical checkpoint to CPU, not GPU
+
+`_load_dcp_canonical` reads *every* weight into one dict. That's ~42
+GB for a 20B model, ~218–234 GB for 120B. If
+`torch.set_default_device("cuda")` is set, the entire canonical lands on
+the GPU and OOMs before the model even builds.
+
+### Fix
+
+Always allocate on CPU in the metadata iteration:
+
+```python
+for key, meta in metadata.state_dict_metadata.items():
+    if key.startswith(prefix):
+        sd[key] = torch.empty(meta.size, dtype=meta.properties.dtype, device="cpu")
+dcp.load(sd, checkpoint_id=dcp_path, no_dist=True)
+```
+
+Filter to this rank's keys, then `.to(device)` only the filtered
+result.
+
+## The `.weight` suffix depends on storage style
+
+- `nn.Linear` / `nn.Embedding` / `GroupLinear`: state_dict key ends
+  in `.weight`.
+- Raw `nn.Parameter` stored on the module itself: state_dict key is
+  just the attribute name, **no `.weight`**.
+
+Our canonical DCP keys must match the model's actual `state_dict()`
+spelling. If the model uses raw `nn.Parameter` (like GPT-OSS experts),
+the canonical key is
+`layers.0.mlp.experts.0.gate_up_proj` (no `.weight`).
+
+### Symptom of a mismatch
+
+`load_state_dict(strict=False)` silently reports every expert weight
+as "missing" and the model runs on random initialisation. Inference
+produces gibberish; training starts from scratch instead of resuming.
+
+### Check
+
+```python
+print(sorted(model.state_dict().keys())[:20])
+# Compare against one-off print of your canonical keys
+```
+
+## Small bias gradients below the bf16 noise floor
+
+`router.bias` (zero-init), layer-norm weights, attention biases —
+their gradients per micro-batch can land at `~1e-9` in bf16. bf16's
+7-bit mantissa gives ~1% relative precision, which accumulated through
+8 layers of backward produces 5–20% per-element direction noise
+between reference and 5-stage even when the math is identical.
+`calc_diff` then reports a false failure.
+
+### Fix
+
+Scale the labels — not the threshold:
+
+```python
+label_scale = 10.0
+full_l = label_scale * torch.randn(..., dtype=dtype)
+```
+
+MSE gradients are linear in the residual, so 10× label scale moves the
+affected gradients from `~1e-9` into `~1e-8`, above the noise floor.
+Larger gradients on well-conditioned parameters are unaffected (they
+were already out of the noise floor).
+
+See `testing.md` for the "when to trust the threshold" decision.
+
+## Don't relax the threshold, don't skip by name
+
+When a test fails, the temptation is to loosen `eps` or add a
+name-based skip. **Don't.** Both hide real regressions:
+
+- Loosened `eps` → future bugs in well-behaved gradients go unnoticed.
+- Name skips → the skipped parameter has a permanent blind spot;
+  refactors that also affect it silently regress.
+
+Instead, print magnitudes and diagnose. See
+`testing.md` §decision-tree.
+
+## HF has some quirks to watch for
+
+- **`quantization_config` in config.json** — if your `dcp2hf` writes
+  BF16 safetensors but inherits the source config, transformers will
+  still try to interpret the weights as quantized. Strip the key and
+  set `torch_dtype: "bfloat16"` before round-trip loading.
+- **`score_mod` closures over Parameters** — forces
+  `flex_attention` to self-compile, which breaks our
+  `fullgraph=True` outer compile. Use the LSE-renorm pattern instead
+  (see `compile.md`).
+- **`rope_scaling.rope_type == "yarn"` has a mscale concentration
+  factor** — `0.1 * log(scaling_factor) + 1.0`. Don't skip it; it's
+  not a bug in HF, it's the spec. Matches OpenAI's reference
+  implementation for GPT-OSS.
+
+## Also watch for
+
+- **`num_hidden_layers` truncation parallel arrays.** Configs sometimes
+  have `layer_types`, `attention_pattern`, or similar per-layer
+  arrays. When you truncate `num_hidden_layers` in the single-GPU /
+  FSDP tests, truncate these parallel arrays to match, or the model
+  will read past the end.
+
+- **Don't commit ad-hoc test scripts.** Model-specific single-GPU /
+  inference tests are working-stage tools. They live next to
+  `tests/` as untracked files; they are not part of the committed
+  test suite.
+
+- **Don't commit `docs/`, `CLAUDE.md`, or `.claude/`.** Per user
+  preferences. This skill itself lives under `.claude/skills/` — it's
+  not committed.

--- a/.claude/skills/add-new-model/reference/protocol.md
+++ b/.claude/skills/add-new-model/reference/protocol.md
@@ -1,0 +1,400 @@
+# The 5-Stage DualPipeV Protocol
+
+This reference defines the contract every new model must satisfy. It also
+covers the model-level `forward` / `backward` and the critical
+stage-record copy pattern. Keep `pithtrain/models/interface.py` and an
+existing model (`pithtrain/models/qwen3_30b_a3b.py` is cleanest) open
+alongside this file while writing.
+
+## The five stages
+
+Every decoder layer is split into 5 stages by the scheduler:
+
+| Stage | Method | Owner | What runs |
+|-------|--------|-------|-----------|
+| 1 | `forward_attn` | model | LN + Attn + LN + (shared-experts?) + Gate + EP dispatch prep |
+| 2 | (framework) | framework | All-to-all dispatch on comm stream |
+| 3 | `forward_mlp` | model | Scatter-by-expert + grouped GEMM + unshuffle |
+| 4 | (framework) | framework | All-to-all combine on comm stream |
+| 5 | `forward_aggregate` | model | Weighted expert sum + residual add |
+
+Plus a non-pipelined `reference_forward` for testing/inference.
+
+## `DecoderLayerProtocol` (see `pithtrain/models/interface.py`)
+
+```python
+class DecoderLayerProtocol(Protocol):
+    idx: int                   # layer index (used by nvtx range labels)
+    mlp: DecoderLayerMlpProtocol   # must expose ep_size + ep_group
+
+    def reference_forward(self, hidden_states) -> Tensor: ...
+    def forward_attn(self, hidden_states) -> ForwardAttnOutput: ...
+    def forward_mlp(
+        self, gathered_tokens, expert_idxs=None, expand_idx=None
+    ) -> Tensor: ...
+    def forward_aggregate(
+        self, moe_outs, moe_local_idxs, topk_weight, residual
+    ) -> Tensor: ...
+```
+
+`ForwardAttnOutput` is a `NamedTuple` with `sorted_tokens`, `moe_local_idxs`,
+`topk_weight`, `output_splits`, `input_splits`, `expert_idxs`, `residual`,
+and optionally `expand_idx`, `dedup_input_splits`, `dedup_output_splits`.
+For a dense (non-MoE) layer, set the MoE fields to `None` and return
+`hidden_states` as `sorted_tokens`.
+
+## Stage 1: `forward_attn` — the glue stage
+
+This is where everything before the expert dispatch happens. The general
+shape is:
+
+```python
+@torch.compile(fullgraph=True)
+def _forward_attn_compute(self, hidden_states):
+    residual = hidden_states
+    hidden_states = self.input_layernorm(hidden_states)
+
+    # Position embeddings / block masks are set on the layer before the
+    # call (by Model.forward). See qwen3/gpt_oss for the pattern.
+    hidden_states = self.self_attn(hidden_states, position_embeddings=..., ...)
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = self.post_attention_layernorm(hidden_states)
+
+    # SHARED EXPERTS (if any) go HERE — fold into residual BEFORE return.
+    # This overlaps their compute with the stage-2 all-to-all dispatch
+    # of the routed tokens.
+    if hasattr(self.mlp, "shared_experts"):
+        residual = residual + self.mlp.shared_experts(hidden_states)
+
+    return hidden_states, residual
+
+def forward_attn(self, hidden_states) -> ForwardAttnOutput:
+    hidden_states, residual = self._forward_attn_compute(hidden_states)
+
+    # Dense (no routing)
+    if not hasattr(self.mlp, "experts"):
+        return ForwardAttnOutput(
+            hidden_states, None, None, None, None, None, residual,
+        )
+
+    # MoE routing + dispatch prep
+    topk_ids, topk_weight = self.mlp.router(hidden_states)   # or .gate — match HF
+    (sorted_tokens, idxs, expert_idxs, expand_idx,
+     dedup_input_splits, dedup_output_splits,
+     input_splits, output_splits) = moe_ep_prepare_dispatch(
+        hidden_states,
+        topk_ids,
+        self.mlp.num_experts,
+        self.mlp.ep_size,
+        self.mlp.experts_per_rank,
+        self.mlp.ep_group,
+    )
+    return ForwardAttnOutput(
+        sorted_tokens, idxs, topk_weight,
+        output_splits, input_splits, expert_idxs, residual,
+        expand_idx, dedup_input_splits, dedup_output_splits,
+    )
+```
+
+### Attention kernel unwrap pattern
+
+If your attention uses `flex_attention` or ring attention, *those kernels
+compile themselves*. Nested compile fails (`compile-inside-compile`).
+The narrowly-scoped fix is to unwrap `_forward_attn_compute` **only when
+the incompatible kernel is active**. See `compile.md` for full detail;
+the short version in Qwen3 / DeepSeek-V2 is:
+
+```python
+if self.self_attn.use_ring_attn:
+    self._forward_attn_compute = self._forward_attn_compute.__wrapped__.__get__(
+        self, type(self)
+    )
+```
+
+For attention with sinks (GPT-OSS pattern) — don't use `score_mod`
+closures that capture learned Parameters. Use `return_aux=AuxRequest(lse=True)`
+and renormalize as a post-op. See `compile.md`.
+
+## Stage 3: `forward_mlp` — grouped expert GEMM
+
+```python
+def forward_mlp(self, gathered_tokens, expert_idxs=None, expand_idx=None):
+    # Dense fallback
+    if not hasattr(self.mlp, "experts"):
+        assert expert_idxs is None
+        return self.mlp(gathered_tokens)
+
+    assert expert_idxs is not None
+    # Use padded_index_gather, NOT raw gathered_tokens[expand_idx] — the
+    # padded version is safe over the padding rows that scatter allocates.
+    if expand_idx is not None:
+        gathered_tokens = padded_index_gather(gathered_tokens, expand_idx)
+
+    output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks, ks_tensor = (
+        scatter_for_grouped_gemm(gathered_tokens, expert_idxs, self.mlp.experts_per_rank)
+    )
+    del gathered_tokens
+    outs = self.mlp.experts(output_tokens, grouped_mm_offs, ks=ks, ks_tensor=ks_tensor)
+    outs = padded_index_gather(outs, reverse_shuffle_idxs)   # not outs[reverse_shuffle_idxs]
+    return outs
+```
+
+**Inside the experts `forward`, truncate to `sum(ks)` before the matmul
+if the experts do bias-add or elementwise post-ops.** `F.grouped_mm`
+leaves rows beyond `offs[-1]` uninitialised (often NaN), and
+`bias[group_ids] + NaN` propagates during backward as `0 * NaN = NaN`,
+poisoning bias gradients. See `pitfalls.md`.
+
+```python
+def forward(self, x, grouped_mm_offs, ks=None, ks_tensor=None):
+    if ks is not None:
+        actual_m = sum(ks)
+        if actual_m < x.shape[0]:
+            x = x[:actual_m]
+    # ... rest of grouped GEMM ...
+```
+
+## Stage 5: `forward_aggregate` — weighted sum + residual
+
+```python
+@torch.compile(fullgraph=True)
+def forward_aggregate(self, moe_outs, moe_local_idxs, topk_weight, residual):
+    if hasattr(self.mlp, "experts"):
+        if self.mlp.ep_size > 1:
+            # EP path: moe_local_idxs maps back through dedup
+            assert moe_local_idxs is not None
+            seq_len, topk = topk_weight.shape
+            permuted_probs = topk_weight.view(-1)[moe_local_idxs]
+            token_indices = moe_local_idxs // topk
+            weighted = (moe_outs.float() * permuted_probs.unsqueeze(-1)).to(moe_outs.dtype)
+            hidden_states = moe_outs.new_zeros(seq_len, moe_outs.shape[-1])
+            hidden_states.scatter_add_(0, token_indices[:, None].expand_as(weighted), weighted)
+            hidden_states = hidden_states.view(*residual.shape)
+        else:
+            # Non-EP: just weighted sum
+            assert moe_local_idxs is None
+            final_out = moe_outs.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(-1)
+            hidden_states = final_out.sum(dim=1).to(moe_outs.dtype).view(*residual.shape)
+    else:
+        assert moe_local_idxs is None and topk_weight is None
+        hidden_states = moe_outs
+
+    # Residual here closes the decoder block.  Shared-expert output was
+    # already folded into `residual` by _forward_attn_compute, so we do
+    # NOT re-add it here.
+    return residual + hidden_states
+```
+
+## `reference_forward` — the non-pipelined path
+
+Pure eager, no compile, no all-to-all. It's used by:
+
+- the single-GPU sanity test,
+- the FSDP correctness test's reference model (ep=1, single stage),
+- `Model.forward` when `ModelImplMode.use_reference_fwd = True`.
+
+```python
+def reference_forward(self, hidden_states):
+    residual = hidden_states
+    hidden_states = self.input_layernorm(hidden_states)
+    hidden_states = self.self_attn(hidden_states, position_embeddings=...)
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = self.mlp(hidden_states)        # full MoE inside .mlp.forward
+    return residual + hidden_states
+```
+
+If the attention has a ring-attention path, `reference_forward` should
+**disable it** (set a flag, call the non-ring branch). Tests run on a
+single non-CP reference to decouple from CP correctness.
+
+The `self.mlp.forward` called here runs `moe_infer` with `ep_size == 1`
+assertion — the reference is always non-EP.
+
+## Model-level `forward` — the stage-record copy
+
+This is the most error-prone part of the whole integration. `Model.forward`
+runs every decoder layer, but depending on whether the scheduler has
+pre-allocated `IntermediateTensors`, it either returns a plain hidden
+state (training reference / eager inference) or records every stage's
+args/ctx/outs so backward can find them.
+
+### The gotcha
+
+Stages 2 and 4 (dispatch/combine) have `.ctx` only — no `.args`. Skipping
+them "because they don't have `args`" silently drops the all-to-all
+context and you get a cryptic "invalid gradient shape" several stages
+later.
+
+### The correct pattern
+
+Copy this loop verbatim from Qwen3 / GPT-OSS and change only the model
+class reference:
+
+```python
+from dataclasses import fields
+# ...
+layer_idx = 0
+if self.embed_tokens is not None:
+    intermediate_tensors.prolog.args = PrologArgs()
+    intermediate_tensors.prolog.outs = PrologOuts(hidden_states)
+
+for _, layer in self.layers.items():
+    ret = decoder_layer_forward(layer, hidden_states)
+    if len(ret) == 2:
+        hidden_states, layer_record = ret
+        dst = intermediate_tensors.layers[layer_idx]
+        # Iterate EVERY field of the record (Stage1Record, Stage2Record, ...).
+        # Do NOT special-case on hasattr(record, 'args').
+        for field in fields(layer_record):
+            src_rec = getattr(layer_record, field.name)
+            dst_rec = getattr(dst, field.name)
+            for rf in fields(src_rec):
+                setattr(dst_rec, rf.name, getattr(src_rec, rf.name))
+    else:
+        hidden_states = ret[0]
+        dst = intermediate_tensors.layers[layer_idx]
+        for field in fields(dst):
+            record = getattr(dst, field.name)
+            for rf in fields(record):
+                setattr(record, rf.name, None)
+    layer_idx += 1
+
+if self.norm is not None:
+    assert self.lm_head is not None
+    if not ModelImplMode.use_reference_fwd:
+        hidden_states = hidden_states.detach().requires_grad_()
+    intermediate_tensors.epilog.args = EpilogArgs(hidden_states)
+    hidden_states = self.norm(hidden_states)
+    hidden_states = self.lm_head(hidden_states)
+
+return hidden_states
+```
+
+The "plain forward" branch (no `intermediate_tensors`) is what the
+`reference_forward` path falls into when the scheduler isn't involved.
+
+## Model-level `backward`
+
+Static method. Runs the epilog backward first (cross-entropy → grad on
+hidden_states), then loops through layers in reverse driving
+`decoder_layer_backward`, then runs prolog backward via `run_backward`.
+Again, copy from Qwen3 / GPT-OSS verbatim:
+
+```python
+@staticmethod
+def backward(module, dy, loss, intermediate_tensors):
+    assert (dy is None) != (loss is None)
+
+    if loss is not None:
+        assert module.norm is not None
+        assert module.lm_head is not None
+        loss.backward()
+        loss.detach_()
+        dy = (intermediate_tensors.epilog.args.hidden_states.grad,)
+        intermediate_tensors.epilog.args = None
+        loss = None
+    else:
+        assert module.norm is None
+        assert module.lm_head is None
+
+    dx = dy
+    layers_list = [layer for _, layer in module.layers.items()]
+    for layer, intermediate_tensors_layer in zip(
+        reversed(layers_list), reversed(intermediate_tensors.layers)
+    ):
+        dx = (decoder_layer_backward(layer, dx, loss, intermediate_tensors_layer),)
+
+    final_grads = dx
+    if module.embed_tokens is not None:
+        record = intermediate_tensors.prolog
+        run_backward(record.outs, dx)
+        for rf in fields(record):
+            setattr(record, rf.name, None)
+        final_grads = (None,)
+
+    return final_grads
+```
+
+## Model.__init__ requirements <a id="init-requirements"></a>
+
+- `self.stage_id`, `self.num_stages` stored for later checks.
+- Layers distributed via `layer_partition(config.num_hidden_layers, num_stages)`.
+- `self.layers` is an `nn.ModuleDict` keyed by the absolute layer id as a
+  string (required by FSDP wrapping and by `init_weights`).
+- First stage has `self.embed_tokens`; last stage has `self.norm` and
+  `self.lm_head`. All other stages set these to `None`.
+- Any "setup" tensors that decoder layers need per-forward (cos/sin
+  caches, block masks, sink parameters) are set on each layer from
+  `forward` before calling `decoder_layer_forward`. Do not bake them
+  into the layer `__init__` (they depend on input seq_len).
+
+### Fail loud on unsupported parallelism dimensions
+
+`setup_model` passes every model a consistent set of process groups
+(`cp_group`, any future parallelism groups). A model that doesn't
+implement a dimension **must reject** a non-trivial group for that
+dimension — silently ignoring the argument will produce wrong results
+the first time a real group is passed, and the bug is hard to trace.
+
+Keep the parameter in the signature for interface parity, and reject at
+the top of `__init__`:
+
+```python
+class <Prefix>Model(nn.Module):
+    def __init__(
+        self,
+        config,
+        num_stages: int,
+        stage_id: int,
+        cp_group: dist.ProcessGroup | None = None,
+    ):
+        super().__init__()
+        if cp_group is not None and cp_group.size() > 1:
+            raise NotImplementedError(
+                "<Prefix>Model does not support context parallelism."
+            )
+        # ... rest of __init__ ...
+```
+
+When the dimension *is* implemented (Qwen3, DeepSeek-V2 with ring
+attention), the parameter is used normally. When it's not (any model
+that doesn't have a ring-attention path), the `NotImplementedError`
+converts a silent correctness bug into a loud configuration error.
+
+**Rule:** when a new model is wired into `setup_model`, walk every
+process-group argument it accepts and confirm it is either (a)
+genuinely used or (b) rejected with `NotImplementedError` when
+`size() > 1`. "Unused but accepted" is the hardest class of silent
+correctness bug to find.
+
+## Router / Gate contract
+
+The router class must provide:
+
+- `self.num_experts: int` — used by `moe_ep_prepare_dispatch` and by
+  the load balance loss init.
+- `self.weight: nn.Parameter(shape=(num_experts, hidden_size))` — router
+  projection weight.
+- `self.load_balance_loss_fn` attribute initialised to `None`. It is set
+  externally by `setup_model` in `pithtrain/modules/training.py`. The
+  injector pattern is:
+  ```python
+  if self.training and self.load_balance_loss_fn is not None:
+      lb_loss = self.load_balance_loss_fn(scores, topk_idx, num_experts, num_experts_per_tok)
+      topk_weight = MoELoadBalanceLossInjector.apply(topk_weight, lb_loss)
+  ```
+- A `@torch.compile(fullgraph=True) compute(...)` that returns
+  `(topk_idx, topk_weight, lb_loss)`.
+- A `forward(...)` that wraps `compute(...)` and calls
+  `MoELoadBalanceLossTracker.add(lb_loss)` when the loss is present.
+
+`setup_model` locates the gate by trying both common attribute names:
+```python
+gate = getattr(layer.mlp, "gate", None) or getattr(layer.mlp, "router", None)
+```
+Either name is fine; match HF's spelling.

--- a/.claude/skills/add-new-model/reference/testing.md
+++ b/.claude/skills/add-new-model/reference/testing.md
@@ -1,0 +1,318 @@
+# Testing Strategy
+
+Tests in order: single-GPU sanity → FSDP pp/ep scaling ladder →
+(optional) inference ladder. Each tier catches a different failure
+class. Never skip tiers.
+
+## Hardware hygiene (apply every command)
+
+Shared cluster. Always check which GPUs are free before running
+anything that touches CUDA:
+
+```bash
+nvidia-smi --query-gpu=index,memory.used,memory.free --format=csv
+```
+
+Pick indices whose `memory.used` is under ~1000 MiB. Do this check
+**again** before each command, not once at the start of the session —
+another user can grab GPUs between your runs. When running multiple
+torchruns in sequence, reset the chosen GPU set each time.
+
+## Timeouts (keep them short)
+
+- Single-GPU sanity: 120s
+- `test_fsdp.py` at pp=1/ep=1: 120s
+- `test_fsdp.py` at pp≥2 or ep≥2: 180s
+- Inference autoregressive decode: 180s
+
+If the test exceeds the timeout, it is **hanging**, not slow. The
+usual cause is torch.compile retracing on a new seq_len (see
+`compile.md` on static-seq-len decode). Kill and diagnose; don't raise
+the timeout.
+
+## Tier 1 — Single-GPU sanity
+
+Model-specific, **ad-hoc** (not committed). Base on
+`tests/test_gpt_oss_single_gpu.py`.
+
+**What it checks:** can we build the model, run `reference_forward`
+to completion on 1 GPU, then run the 5-stage path and see bounded
+relative drift.
+
+```python
+# tests/test_<model>_single_gpu.py  (ad-hoc; don't commit)
+import torch, torch.nn.functional as F
+from transformers import AutoConfig
+from pithtrain.layers.factory import ModelImplMode
+from pithtrain.models.<model> import <Model>Model
+
+torch.manual_seed(1234)
+device = torch.device("cuda")
+torch.set_default_device(device)
+
+config = AutoConfig.from_pretrained("examples/pretrain_language_model/<model>/config.json")
+# Truncate layers to keep the test fast.  Also truncate any
+# parallel arrays like layer_types to match.
+keep = min(config.num_hidden_layers, 4)
+if getattr(config, "layer_types", None) is not None:
+    config.layer_types = config.layer_types[:keep]
+config.num_hidden_layers = keep
+config.ep_size = 1
+
+model = <Model>Model(config, num_stages=1, stage_id=0)
+# Init any raw-Parameter experts (needed when not using GroupLinear)
+for p in model.parameters():
+    if p.dim() >= 2:
+        torch.nn.init.normal_(p, mean=0.0, std=0.02)
+model.to(dtype=torch.bfloat16)
+model.train()
+
+bsz, seq_len = 2, 128
+input_ids = torch.randint(0, config.vocab_size, (bsz, seq_len))
+labels = torch.randn(bsz, seq_len, config.vocab_size, dtype=torch.bfloat16)
+
+# Reference path
+ModelImplMode.use_reference_fwd = True
+logits = model(input_ids)
+assert torch.isfinite(logits).all()
+loss = F.mse_loss(logits.float(), labels.float())
+loss.backward()
+
+# 5-stage path
+ModelImplMode.use_reference_fwd = False
+model.zero_grad()
+logits2 = model(input_ids)
+F.mse_loss(logits2.float(), labels.float()).backward()
+
+# Comparison — bf16 compile-vs-eager noise bound
+ModelImplMode.use_reference_fwd = True
+logits_ref = model(input_ids)
+diff = (logits_ref.float() - logits2.float()).abs().max().item()
+rel = diff / logits_ref.float().abs().max().clamp(min=1e-6).item()
+print(f"rel={rel:.4e}")
+assert rel < 0.8, f"5-stage diverges from reference: rel={rel}"
+```
+
+### Why `rel < 0.8` and not tighter
+
+Random-init bf16 through compile-vs-eager produces per-logit drift
+that's ~20–30% of the max logit at 2–4 layers — this is expected. The
+accumulated drift comes from:
+
+1. `@torch.compile(fullgraph=True)` on `forward_aggregate` re-fusing
+   the weighted sum differently from eager.
+2. `F.grouped_mm` tile shapes depending on tokens-per-expert, which
+   differs between the reference and 5-stage paths.
+3. Fused-vs-split kernels choosing different accumulation orders.
+
+The single-GPU test is an **orders-of-magnitude sanity check**, not a
+numerical tolerance. Do not tighten it based on a single passing run.
+
+## Tier 2 — FSDP pp/ep scaling ladder
+
+Run `tests/test_fsdp.py` in 4 configurations, in this order:
+
+| Config | GPUs | What it adds | Catches |
+|--------|------|-------------|---------|
+| pp=1/ep=1 | 1 | baseline FSDP + DualPipeV scheduler | modeling bugs, NaN, compile drift |
+| pp=2/ep=1 | 2 | pipeline P2P send/recv | stage-record copy bugs, backward shape errors |
+| pp=1/ep=2 | 2 | all-to-all dispatch + combine + dedup | expert-sharding bugs, bias-slicing bugs |
+| pp=2/ep=2 | 4 | full combination | nothing new; regression check |
+
+If step N passes and N+1 fails, the *new* parallelism dimension added
+in N+1 is the suspect.
+
+```bash
+# Check GPUs
+nvidia-smi --query-gpu=index,memory.free --format=csv
+
+# Configuration knobs:
+CFG=examples/pretrain_language_model/<model>/config.json
+RDZV="--rdzv-backend=c10d --rdzv-endpoint=localhost:15213"
+
+# 1. pp=1, ep=1 (one GPU)
+CUDA_VISIBLE_DEVICES=<g0> timeout 180 torchrun --nproc-per-node=1 $RDZV \
+  tests/test_fsdp.py --pp-size 1 --ep-size 1 --model $CFG
+
+# 2. pp=2, ep=1 (two GPUs)
+CUDA_VISIBLE_DEVICES=<g0>,<g1> timeout 180 torchrun --nproc-per-node=2 $RDZV \
+  tests/test_fsdp.py --pp-size 2 --ep-size 1 --model $CFG
+
+# 3. pp=1, ep=2 (two GPUs — re-check nvidia-smi, pick fresh)
+CUDA_VISIBLE_DEVICES=<g0>,<g1> timeout 180 torchrun --nproc-per-node=2 $RDZV \
+  tests/test_fsdp.py --pp-size 1 --ep-size 2 --model $CFG
+
+# 4. pp=2, ep=2 (four GPUs)
+CUDA_VISIBLE_DEVICES=<g0>,<g1>,<g2>,<g3> timeout 180 torchrun --nproc-per-node=4 $RDZV \
+  tests/test_fsdp.py --pp-size 2 --ep-size 2 --model $CFG
+```
+
+### What the test validates
+
+- **Loss match:** `torch.allclose(loss, loss_ref, rtol=1e-3, atol=1e-3)`.
+- **Gradient match:** `calc_diff < 1e-2` per parameter, where
+  `calc_diff = 1 - 2*(x*y).sum() / (x*x + y*y).sum()` (cosine-ish).
+
+Loss matches, grads don't → issue in backward. Loss doesn't match →
+issue in forward.
+
+### What to change in `tests/test_fsdp.py` when adding a new model
+
+1. Add the model config path to the `models` list at the bottom.
+2. Import the new `<Model>Model`, router/gate class, and Experts class
+   (only if experts are raw `nn.Parameter`).
+3. Add the new class to `apply_fsdp`'s `isinstance` assertion tuple.
+4. Add a `config.model_type` branch in `main` that sets
+   `ModelClass = <Model>Model` and truncates `num_hidden_layers` to 8
+   (plus any parallel arrays, like `layer_types` for GPT-OSS).
+5. Add `fill_weights` branches (see below).
+6. Extend `shard_experts` only if the model uses an unusual raw-Parameter
+   name — the existing `gate_up_proj` gate covers GPT-OSS-style experts.
+
+### `fill_weights` branches
+
+`fill_weights` is class-dispatched: it relies on
+`isinstance(module, <SomeClass>)` to know what to initialise. The
+existing branches are `nn.Linear`, `GroupLinear`, `GptOssExperts`,
+`DeepseekV2LiteMoEGate`/`Qwen3MoeGate`/`GptOssTopKRouter`, and
+`nn.Embedding`.
+
+Add a branch when:
+
+- **Raw-Parameter experts** — the `GroupLinear` branch won't reach
+  them, and they'll stay at their `torch.empty()` state, which on our
+  system is zero. Symptom: every MoE layer emits
+  `[warn] Parameter ... has all-zero gradient`. Without this branch,
+  `mlp(x) == 0` in every layer and the residual stream is unchanged.
+  See `pitfalls.md` §silent-zero-experts.
+
+- **New router/gate Parameters** beyond `weight` (e.g. a per-expert
+  `bias` like GPT-OSS has).
+
+```python
+elif isinstance(module, <Model>Experts):   # raw-Parameter experts
+    nn.init.xavier_uniform_(module.gate_up_proj, gain=1.0)
+    nn.init.xavier_uniform_(module.down_proj, gain=1.0)
+elif isinstance(module, (<...existing gates>, <Model>Router)):
+    nn.init.xavier_uniform_(module.weight, gain=1.0)
+    if getattr(module, "bias", None) is not None:
+        nn.init.zeros_(module.bias)
+```
+
+### `shard_experts` fallback
+
+`shard_experts` walks the module tree. For each `GroupLinear` child, it
+slices by expert and replaces with a smaller module. For raw-Parameter
+experts, there's a fallback that detects them by a distinctive weight
+name (not just `num_experts`):
+
+```python
+gu = getattr(model, "gate_up_proj", None)
+if isinstance(gu, nn.Parameter):
+    num_experts = getattr(model, "num_experts", None)
+```
+
+**Do not gate only on `num_experts` alone** — the router has
+`num_experts` too, and sharding it breaks routing (every rank needs
+the full per-expert table). Extend the gate with *your model's
+distinctive expert-weight Parameter name*.
+
+## The label-scaling gotcha
+
+`test_fsdp.py` scales labels by `label_scale = 10.0`:
+
+```python
+full_l = label_scale * torch.randn(
+    ep_size * num_chunks * micro_batch_size, sequence_length, vocab_size, dtype=dtype,
+)
+```
+
+This is deliberate. MSE gradients are linear in the residual. Without
+the scale, tiny-gradient parameters (zero-init router biases, layer-norm
+weights, attention biases) produce gradients at ~1e-9 in bf16, which is
+at the bf16 mantissa noise floor. `calc_diff` then measures rounding,
+not algorithmic correctness, and reports false failures.
+
+### If `calc_diff` fails on a tiny bias
+
+**Do not loosen the threshold first.** Print magnitudes:
+
+```python
+print(f"{n}: p_grad mag={p_grad.abs().max():.4e}, "
+      f"p_ref.grad mag={p_ref.grad.abs().max():.4e}, "
+      f"diff={diff:.4e}")
+```
+
+- If both magnitudes are `~1e-9` or smaller → raise `label_scale` (or
+  switch to cross-entropy loss; MSE on one-hot-like labels also helps).
+- If magnitudes differ by `>10x` → it's a real bug. Look at the stage
+  where the gradient diverges.
+
+See `lessons §23` for the full diagnosis pattern.
+
+## Tier 3 — Inference ladder (optional)
+
+Only when the user wants real-weight inference. Base on
+`tests/test_gpt_oss_inference.py`. Same scaling ladder as training:
+
+```bash
+# 1/1 first
+CUDA_VISIBLE_DEVICES=<g0> timeout 180 torchrun --nproc-per-node=1 $RDZV \
+  tests/test_<model>_inference.py --pp-size 1 --ep-size 1
+
+# Then 2/1, 1/2, 2/2 — same structure as test_fsdp
+```
+
+Check: all four configurations produce *coherent* text (human-judged),
+and should produce identical tokens within bf16 noise. Divergence between
+configurations is a bug, not acceptable.
+
+## When a test fails — the decision tree
+
+```
+Test fails
+├─ Is this a loss mismatch or a grad mismatch?
+│
+├── Loss mismatch
+│    └─ Forward has a bug.  Diff reference vs 5-stage with
+│       `reference_forward` one layer at a time.
+│
+└── Grad mismatch (loss matches)
+     ├─ Print magnitudes (p_grad vs p_ref.grad for the worst param)
+     │
+     ├── Both magnitudes in bf16 noise (~1e-9 or less)
+     │    └─ Raise label_scale.  Probably not a real bug.
+     │       See lessons §23.
+     │
+     ├── Magnitudes differ by >10x
+     │    ├─ Gradient is huge vs reference → NaN propagation
+     │    │  (forward pad rows → backward 0*NaN=NaN).  Truncate to
+     │    │  sum(ks) in expert forward.  See pitfalls.md.
+     │    │
+     │    ├─ Gradient is much smaller than reference → a path isn't
+     │    │  accumulating.  Check stage-record copy.  See protocol.md.
+     │    │
+     │    └─ All-zero gradients on MoE parameters → fill_weights miss.
+     │       See pitfalls.md §silent-zero-experts.
+     │
+     └── Magnitudes similar, but signs or per-element are off
+          └─ Real algorithmic bug.  Bisect by stage (disable one at a
+             time via use_reference_fwd).
+```
+
+## Don't
+
+- Don't relax `rtol`/`atol` on the loss assertion. Loss is well within
+  bf16 tolerance when forward is correct.
+- Don't relax `eps = 1e-2` on `calc_diff` without first printing
+  magnitudes. The noise floor lives at eps=1e-3 for reasonably-scaled
+  gradients; 1e-2 is already generous.
+- Don't add `--skip-<param-name>` flags. Either the test passes for
+  every parameter or the model has a bug. Name-based skips become
+  permanent blind spots.
+- Don't set `dynamic=True` on compile to "fix" inference retracing.
+  Fix it in the test harness with static-seq-len decode — the model
+  code must stay identical to training.
+- Don't run at full `num_chunks=20` during iteration. Use `num_chunks = pp_size * 2`
+  (the minimum DualPipeV allows) with `sequence_length=32` or 64.
+  Restore full workload only for the final regression check.

--- a/.claude/skills/add-new-model/templates/inference_test.py
+++ b/.claude/skills/add-new-model/templates/inference_test.py
@@ -1,0 +1,360 @@
+"""
+End-to-end DualPipeV inference test — TEMPLATE.
+
+Copy this to ``tests/test_<model>_inference.py`` (ad-hoc, not committed),
+replace the TODO_MODEL markers with the new model's class and HF ID, and
+run it through the pp/ep scaling ladder.
+
+The purpose of this test is to verify that **real released weights**
+produce coherent text when run through **DualPipeV's 5-stage pipeline**
+(not the raw model forward).  This catches:
+  • checkpoint-conversion layout bugs (symptom: gibberish even after
+    FSDP gradient test passes with random weights),
+  • pipeline plumbing issues that only manifest with loaded weights,
+  • regressions in the stage scheduler under inference.
+
+Gradual scaling — same ladder as training:
+    # 1 GPU
+    CUDA_VISIBLE_DEVICES=<g0> timeout 180 torchrun --nproc-per-node=1 \\
+        --rdzv-backend=c10d --rdzv-endpoint=localhost:15213 \\
+        tests/test_<model>_inference.py --pp-size 1 --ep-size 1
+
+    # 2 GPUs — pp
+    CUDA_VISIBLE_DEVICES=<g0>,<g1> timeout 180 torchrun --nproc-per-node=2 ... \\
+        tests/test_<model>_inference.py --pp-size 2 --ep-size 1
+
+    # 2 GPUs — ep
+    CUDA_VISIBLE_DEVICES=<g0>,<g1> timeout 180 torchrun --nproc-per-node=2 ... \\
+        tests/test_<model>_inference.py --pp-size 1 --ep-size 2
+
+    # 4 GPUs
+    CUDA_VISIBLE_DEVICES=<g0>,<g1>,<g2>,<g3> timeout 180 torchrun --nproc-per-node=4 ... \\
+        tests/test_<model>_inference.py --pp-size 2 --ep-size 2
+
+**ALWAYS** check `nvidia-smi --query-gpu=index,memory.used,memory.free --format=csv`
+before each torchrun to pick actually-free GPUs.  Shared cluster.
+"""
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed
+import torch.distributed.checkpoint as dcp
+import torch.nn as nn
+from huggingface_hub import snapshot_download
+from torch.distributed.checkpoint import FileSystemReader
+from transformers import AutoConfig, AutoTokenizer
+
+from pithtrain.dualpipe import DualPipeV, set_p2p_tensor_dtype, set_p2p_tensor_shapes
+from pithtrain.layers.factory import ModelImplMode
+
+# TODO_MODEL: import the model class you're testing.
+from pithtrain.models.<model> import <Model>Model  # noqa: F821
+from pithtrain.modules.distributed import DistributedCfg, DistributedCtx, distributed_context
+from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg
+from pithtrain.tasks.convert_checkpoint import launch as convert_launch
+
+
+# TODO_MODEL: default HF id and local root.  The root holds hf/ and dcp/
+# subdirs; both are created lazily on rank 0 when missing.
+DEFAULT_HF_ID = "TODO_MODEL"  # e.g. "mistralai/Mixtral-8x7B-v0.1"
+DEFAULT_ROOT = Path("/tmp/pithtrain-<model>")  # TODO_MODEL
+
+
+# ── checkpoint prep (rank 0 only) ─────────────────────────────────────────
+
+
+def _ensure_dcp_checkpoint(hf_id: str, root: Path):
+    """Download HF snapshot and convert to DCP if not already present."""
+    hf_dir = root / "hf"
+    dcp_dir = root / "dcp"
+    if not dcp_dir.exists():
+        if not hf_dir.exists() or not (hf_dir / "config.json").exists():
+            print(f"[INFO] Downloading {hf_id} into {hf_dir}", flush=True)
+            snapshot_download(
+                repo_id=hf_id,
+                local_dir=hf_dir,
+                # TODO_MODEL: tighten the allow_patterns if the repo has
+                # extra files you don't need (e.g. original PyTorch weights
+                # when you're loading safetensors).
+                allow_patterns=["*.json", "model*.safetensors", "*.txt", "tokenizer*"],
+                ignore_patterns=["original/*", "metal/*"],
+            )
+        print(f"[INFO] Converting HF → DCP into {dcp_dir}", flush=True)
+        cfg = ConvertCheckpointCfg()
+        cfg.operation = "hf2dcp"
+        cfg.load_path = hf_dir
+        cfg.save_path = dcp_dir
+        convert_launch(cfg)
+    return dcp_dir, hf_dir
+
+
+# ── DCP → localized state_dict ────────────────────────────────────────────
+
+
+def _load_dcp_canonical(dcp_path: Path) -> dict:
+    """Read the whole canonical DCP into a CPU dict.
+
+    IMPORTANT: allocate on CPU.  A 20B model is ~42 GB, a 120B model is
+    ~230 GB — if the default device is CUDA, this OOMs before the model
+    is even built.  See reference/pitfalls.md §load-canonical-to-cpu.
+    """
+    metadata = FileSystemReader(str(dcp_path)).read_metadata()
+    prefix = "app.model."
+    sd = {}
+    for key, meta in metadata.state_dict_metadata.items():
+        if key.startswith(prefix):
+            sd[key] = torch.empty(meta.size, dtype=meta.properties.dtype, device="cpu")
+    dcp.load(sd, checkpoint_id=dcp_path, no_dist=True)
+    return {k.removeprefix(prefix): v for k, v in sd.items()}
+
+
+def _load_localized_from_canonical(canonical: dict, dualpipev: DualPipeV) -> dict:
+    """Remap canonical per-expert indexed keys → local FQNs and stack
+    experts for this rank's EP slice.
+
+    Mirrors ``modules.checkpoint.to_localized_model`` but without DTensor
+    wrapping since inference doesn't use FSDP-sharded parameters.
+    """
+    import re
+
+    from pithtrain.modules.checkpoint import MODULE_PREFIX_RE, expert_range
+
+    named_modules = dict(dualpipev.named_modules())
+    indexed = re.compile(r"(.*\.mlp\.experts)\.(\d+)\.(.*)")
+
+    fqn_map = {}
+    for k in dualpipev.state_dict().keys():
+        canon = MODULE_PREFIX_RE.sub("", k)
+        fqn_map[canon] = k
+
+    by_local_key: dict[str, dict[int, torch.Tensor]] = {}
+    plain: dict[str, torch.Tensor] = {}
+    for canon, tensor in canonical.items():
+        m = indexed.match(canon)
+        if m:
+            prefix, idx_str, suffix = m.groups()
+            stacked_canon = f"{prefix}.{suffix}"
+            local = fqn_map.get(stacked_canon)
+            if local is None:
+                continue
+            moe_path = local.partition(".experts.")[0]
+            moe = named_modules.get(moe_path)
+            if moe is None or not hasattr(moe, "ep_rank"):
+                continue
+            start, end = expert_range(moe)
+            idx = int(idx_str)
+            if start <= idx < end:
+                by_local_key.setdefault(local, {})[idx - start] = tensor
+        else:
+            local = fqn_map.get(canon)
+            if local is not None:
+                plain[local] = tensor
+
+    for local_key, by_idx in by_local_key.items():
+        plain[local_key] = torch.stack([by_idx[i] for i in sorted(by_idx)])
+
+    device = torch.cuda.current_device()
+    return {k: v.to(device) for k, v in plain.items()}
+
+
+# ── model builder ─────────────────────────────────────────────────────────
+
+
+def build_dualpipev(config, ctx: DistributedCtx, dtype: torch.dtype) -> DualPipeV:
+    """Build the DualPipeV wrapper around two model replicas (stage_id and
+    its mirror) for this pp_rank.  Inference doesn't wrap with FSDP —
+    DP=CP=1, so sharding has no benefit and DTensor-in-state_dict makes
+    the localization pass messier.
+    """
+    pp_size = ctx.pp_size
+    pp_rank = ctx.pp_rank
+    ep_group = ctx.device_mesh.get_group("ep")
+    pp_group = ctx.device_mesh.get_group("pp")
+
+    config.ep_size = ctx.ep_size
+    num_stages = pp_size * 2
+    modules = [
+        # TODO_MODEL: if the model takes cp_group or other kwargs, pass them here.
+        <Model>Model(config, num_stages=num_stages, stage_id=pp_rank, ep_group=ep_group),  # noqa: F821
+        <Model>Model(  # noqa: F821
+            config, num_stages=num_stages, stage_id=num_stages - 1 - pp_rank, ep_group=ep_group
+        ),
+    ]
+    modules = nn.Sequential(*modules)
+    modules.to(device=torch.cuda.current_device(), dtype=dtype)
+
+    return DualPipeV(modules, pp_group=pp_group, ep_group=ep_group)
+
+
+# ── autoregressive decode via DualPipeV ───────────────────────────────────
+
+
+@torch.no_grad()
+def generate(
+    dualpipev: DualPipeV,
+    ctx: DistributedCtx,
+    tokenizer,
+    prompts: list[str],
+    max_new_tokens: int,
+    dtype: torch.dtype,
+    hidden_size: int,
+) -> list[str]:
+    """Greedy decode with static-seq-len buffer.
+
+    DualPipeV requires ``num_chunks >= pp_size * 2``.  We use one prompt
+    per chunk so ``num_chunks = len(prompts)``.  The caller must pass a
+    batch of at least ``pp_size * 2`` prompts.
+    """
+    device = torch.cuda.current_device()
+    assert len(prompts) >= ctx.pp_size * 2, (
+        f"prompts batch={len(prompts)} must be >= pp_size*2={ctx.pp_size * 2}"
+    )
+    num_chunks = len(prompts)
+
+    enc = [tokenizer.encode(p, return_tensors="pt").squeeze(0) for p in prompts]
+    pad_id = tokenizer.pad_token_id or 0
+
+    # Trim every prompt to the length of the SHORTEST so the batch is
+    # uniform with no left-padding.  Left-padding would contaminate
+    # causal attention on the heavily-padded prompts — see
+    # reference/pitfalls.md §left-padding.
+    prompt_len = min(t.shape[0] for t in enc)
+
+    # Static-seq-len decode: allocate one buffer sized
+    # [batch, prompt_len + max_new_tokens] up front and advance a cursor.
+    # Keeps DualPipeV's p2p shapes constant and the @torch.compile(fullgraph=True)
+    # inside the attention block compiles ONCE instead of once per new
+    # seq_len.  See reference/compile.md §inference-compile.
+    max_seq_len = prompt_len + max_new_tokens
+    buffer = torch.full((len(enc), max_seq_len), pad_id, dtype=torch.long, device=device)
+    for i, t in enumerate(enc):
+        buffer[i, :prompt_len] = t[:prompt_len].to(device)
+    cursor = prompt_len
+    generated = [[] for _ in range(len(prompts))]
+
+    set_p2p_tensor_shapes([(1, max_seq_len, hidden_size)])
+    set_p2p_tensor_dtype(dtype)
+
+    for step in range(max_new_tokens):
+        inputs = buffer if ctx.pp_rank == 0 else None
+        loss, outputs = dualpipev.step(
+            inputs,
+            num_chunks=num_chunks,
+            criterion=None,
+            labels=[],
+            return_outputs=True,
+        )
+
+        next_tok = torch.empty(len(prompts), dtype=torch.long, device=device)
+        if ctx.pp_rank == 0:
+            logits = outputs
+            if isinstance(logits, tuple):
+                logits = logits[0]
+            # Use the logit at position (cursor - 1): the prediction made
+            # by the last real input position.  Positions beyond the cursor
+            # hold pad_id and don't contaminate causal attention from
+            # filled positions.
+            next_tok = logits[:, cursor - 1, :].float().argmax(dim=-1)
+        torch.distributed.broadcast(next_tok, src=0)
+
+        for i, tok in enumerate(next_tok.tolist()):
+            generated[i].append(tok)
+        buffer[:, cursor] = next_tok
+        cursor += 1
+
+    return [tokenizer.decode(g, skip_special_tokens=True) for g in generated]
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+
+
+def main(ctx: DistributedCtx, args):
+    dtype = torch.bfloat16
+    torch.cuda.set_device(ctx.local_rank)
+    torch.set_default_device(torch.cuda.current_device())
+    # Use the 5-stage pipeline path, not reference_forward — the whole
+    # point of this test is to exercise DualPipeV end-to-end.
+    ModelImplMode.use_reference_fwd = False
+
+    if ctx.rank == 0:
+        dcp_path, hf_path = _ensure_dcp_checkpoint(args.hf_id, args.root)
+    else:
+        dcp_path = args.root / "dcp"
+        hf_path = args.root / "hf"
+    torch.distributed.barrier()
+
+    config = AutoConfig.from_pretrained(hf_path)
+    dualpipev = build_dualpipev(config, ctx, dtype)
+
+    if ctx.rank == 0:
+        print(f"[INFO] Loading canonical DCP from {dcp_path}", flush=True)
+    canonical = _load_dcp_canonical(dcp_path)
+    local_sd = _load_localized_from_canonical(canonical, dualpipev)
+    missing, unexpected = dualpipev.load_state_dict(local_sd, strict=False)
+    if ctx.rank == 0 and missing:
+        print(f"[WARN] missing keys (first 10): {list(missing)[:10]}", flush=True)
+    if ctx.rank == 0 and unexpected:
+        print(f"[WARN] unexpected keys (first 10): {list(unexpected)[:10]}", flush=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_path)
+    # Pad the prompt batch up to pp_size * 2 if the user provided fewer —
+    # DualPipeV requires num_chunks >= pp_size * 2.
+    base_prompts = args.prompts
+    min_batch = ctx.pp_size * 2
+    if len(base_prompts) >= min_batch:
+        prompts = list(base_prompts)
+    else:
+        prompts = (base_prompts * ((min_batch + len(base_prompts) - 1) // len(base_prompts)))[
+            :min_batch
+        ]
+
+    if ctx.rank == 0:
+        print(
+            f"[INFO] Generating with pp={ctx.pp_size}, ep={ctx.ep_size}, batch={len(prompts)}",
+            flush=True,
+        )
+    outputs = generate(
+        dualpipev,
+        ctx,
+        tokenizer,
+        prompts,
+        max_new_tokens=args.max_new_tokens,
+        dtype=dtype,
+        hidden_size=config.hidden_size,
+    )
+    if ctx.rank == 0:
+        for p, o in zip(prompts, outputs):
+            print(f"\n[PROMPT] {p!r}", flush=True)
+            print(f"[OUTPUT] {o!r}", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pp-size", type=int, default=1)
+    parser.add_argument("--ep-size", type=int, default=1)
+    parser.add_argument("--hf-id", default=DEFAULT_HF_ID)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument(
+        "--prompts",
+        nargs="+",
+        default=[
+            "The capital of France is",
+            "def fibonacci(n):\n    if n <= 1:",
+            "Once upon a time",
+            "To compute the Fibonacci sequence, you can use",
+        ],
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=16)
+    args = parser.parse_args()
+
+    cfg, ctx = SimpleNamespace(), SimpleNamespace()
+    cfg.distributed = DistributedCfg()
+    cfg.distributed.pipeline_parallel_size = args.pp_size
+    cfg.distributed.expert_parallel_size = args.ep_size
+    ctx.distributed = DistributedCtx()
+
+    with distributed_context(cfg, ctx):
+        main(ctx.distributed, args)

--- a/.claude/skills/add-new-model/templates/model_skeleton.py
+++ b/.claude/skills/add-new-model/templates/model_skeleton.py
@@ -1,0 +1,734 @@
+"""
+<HF model card URL or name>.
+
+STRUCTURAL OUTLINE — NOT a working file.
+
+This template encodes only the framework-side contracts that every
+PithTrain model must satisfy:
+  • the 5-stage decoder-layer interface,
+  • `@torch.compile(fullgraph=True)` on the three hot regions,
+  • shared-expert placement inside `_forward_attn_compute`,
+  • the model-level `forward` stage-record copy and `backward`.
+
+Everything that defines *this* model (class names, attribute names,
+tensor shapes, RoPE variant, attention kernel, expert activation, etc.)
+is marked `TODO_HF` — fill in from HuggingFace's `modeling_<model>.py`
+**before** looking at other PithTrain models.  Do not start from Qwen3 /
+DeepSeek-V2 / GPT-OSS and rename; that path has produced silent
+state_dict mismatches.  See `reference/conventions.md`.
+"""
+
+from dataclasses import fields
+from typing import List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import nn
+
+from pithtrain.dualpipe.execution import EpilogArgs, IntermediateTensors, PrologArgs, PrologOuts
+from pithtrain.dualpipe.layer_partition import layer_partition
+from pithtrain.dualpipe.modeling import decoder_layer_backward, decoder_layer_forward
+from pithtrain.dualpipe.utils import run_backward
+from pithtrain.layers.factory import ModelImplMode, get_linear_cls
+from pithtrain.models.interface import ForwardAttnOutput
+from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
+from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
+from pithtrain.operators.token_scatter import padded_index_gather, scatter_for_grouped_gemm
+
+torch._dynamo.allow_in_graph(MoELoadBalanceLossInjector)
+
+
+# -----------------------------------------------------------------------------
+# Rotary Position Embedding
+#
+# TODO_HF: copy HF's <Prefix>RotaryEmbedding implementation (LLaMA-style,
+# YaRN, linear-scaled, etc.).  Match HF's *class name* exactly — YaRN is
+# an implementation detail, not part of the name.
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixRotaryEmbedding(nn.Module):  # TODO_HF rename to match HF class
+    """<one-line summary>."""
+
+    def __init__(self, dim: int, max_position_embeddings: int, base: float):
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        # TODO_HF: build cos/sin cache identical to HF.
+
+    def forward(self, x: torch.Tensor, seq_len: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        # TODO_HF: return cos[:seq_len], sin[:seq_len] in x's dtype.
+        raise NotImplementedError
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(2)
+    sin = sin.unsqueeze(2)
+    return (q * cos) + (rotate_half(q) * sin), (k * cos) + (rotate_half(k) * sin)
+
+
+# -----------------------------------------------------------------------------
+# Experts
+#
+# TODO_HF: mirror HF's Experts module — class name, attribute names, fused
+# vs split projections.  Storage layout must be `[E, out, in]` (training-
+# framework consensus; see reference/conventions.md).  If HF stores
+# `[E, in, out]`, the transpose lives ONLY in dcp2hf, never here.
+#
+# If HF fuses gate+up into `gate_up_proj`, keep it fused.  Split the
+# output at forward time for different post-ops.
+#
+# CRITICAL: if expert forward has bias-add or elementwise post-ops,
+# truncate x to sum(ks) before the grouped GEMM (see reference/pitfalls.md).
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixExperts(nn.Module):  # TODO_HF rename to match HF class
+    """<one-line summary>."""
+
+    def __init__(self, num_experts: int, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        # TODO_HF: match HF's weight shapes and names.
+        # Example (GPT-OSS style, fused gate+up, `[E, out, in]` layout,
+        # per-expert bias):
+        #   self.gate_up_proj = nn.Parameter(
+        #       torch.empty(num_experts, 2 * intermediate_size, hidden_size))
+        #   self.gate_up_proj_bias = nn.Parameter(
+        #       torch.zeros(num_experts, 2 * intermediate_size))
+        #   self.down_proj = nn.Parameter(
+        #       torch.empty(num_experts, hidden_size, intermediate_size))
+        #   self.down_proj_bias = nn.Parameter(torch.zeros(num_experts, hidden_size))
+
+    def _grouped_mm(
+        self, x: torch.Tensor, weight: nn.Parameter, offs: torch.Tensor
+    ) -> torch.Tensor:
+        # Empty-input guard: grouped_mm dislikes an M=0 input.
+        if x.shape[0] == 0:
+            return x @ weight[0].transpose(-2, -1)
+        # `[E, out, in]` storage → transpose view for F.grouped_mm.
+        return F.grouped_mm(x, weight.transpose(-2, -1), offs=offs)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grouped_mm_offs: torch.Tensor,
+        ks: list | None = None,
+        ks_tensor: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # NaN-padding protection: truncate to sum(ks) before matmul.
+        # See reference/pitfalls.md §nan-padding.
+        if ks is not None:
+            actual_m = sum(ks)
+            if actual_m < x.shape[0]:
+                x = x[:actual_m]
+
+        # TODO_HF: implement the HF expert forward.
+        # Typical SwiGLU pattern:
+        #   gate_up = self._grouped_mm(x, self.gate_up_proj, grouped_mm_offs)
+        #   gate, up = gate_up[:, ::2], gate_up[:, 1::2]     # if fused
+        #   activated = silu(gate) * up    # or clamped-SwiGLU, etc.
+        #   out = self._grouped_mm(activated, self.down_proj, grouped_mm_offs)
+        #   return out
+        raise NotImplementedError
+
+
+# -----------------------------------------------------------------------------
+# Router / Gate
+#
+# TODO_HF: match HF's class name EXACTLY (e.g. `<Prefix>TopKRouter`,
+# `<Prefix>Gate`, etc.) and the attribute name in the MLP module
+# (`self.mlp.router` or `self.mlp.gate`).  State_dict keys depend on this.
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixRouter(nn.Module):  # TODO_HF rename to match HF
+    """<one-line summary>."""
+
+    def __init__(self, hidden_size: int, num_experts: int, num_experts_per_tok: int):
+        super().__init__()
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.load_balance_loss_fn = None  # set externally by setup_model
+        self.weight = nn.Parameter(torch.empty(num_experts, hidden_size))
+        # TODO_HF: add `self.bias = nn.Parameter(torch.zeros(num_experts))` if HF has it.
+
+    @torch.compile(fullgraph=True)
+    def compute(
+        self, hidden_states: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        """Top-k routing — must be fullgraph-compilable.
+
+        TODO_HF: match HF's exact routing math (pre-softmax top-k,
+        post-softmax top-k, norm_topk_prob, etc.).
+        """
+        batch_size, seq_len, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_size)
+
+        # TODO_HF: compute logits, top-k idx, top-k weight per HF's spec.
+        # Common patterns:
+        #   (a) GPT-OSS: softmax over topk_logits only
+        #       logits = F.linear(hidden_states, self.weight, self.bias)
+        #       topk_logits, topk_idx = torch.topk(logits, k=..., dim=-1, sorted=True)
+        #       topk_weight = F.softmax(topk_logits, dim=-1, dtype=torch.float32)
+        #
+        #   (b) Qwen3: softmax-then-topk, optional renormalise
+        #       scores = F.linear(hidden_states, self.weight, None).softmax(
+        #           dim=-1, dtype=torch.float32)
+        #       topk_weight, topk_idx = torch.topk(scores, k=..., dim=-1, sorted=False)
+        #       if self.norm_topk_prob:
+        #           topk_weight = topk_weight / topk_weight.sum(dim=-1, keepdim=True)
+        logits = F.linear(hidden_states, self.weight, None)  # TODO_HF: add bias if HF has it
+        raise NotImplementedError  # complete per HF's spec
+
+        # Load-balance loss injection — copy this block verbatim.
+        if self.training and self.load_balance_loss_fn is not None:
+            scores = logits.softmax(dim=-1, dtype=torch.float32)
+            lb_loss = self.load_balance_loss_fn(
+                scores, topk_idx, self.num_experts, self.num_experts_per_tok
+            )
+            topk_weight = MoELoadBalanceLossInjector.apply(topk_weight, lb_loss)
+        else:
+            lb_loss = None
+
+        return topk_idx, topk_weight, lb_loss
+
+    def forward(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        topk_idx, topk_weight, lb_loss = self.compute(hidden_states)
+        if lb_loss is not None:
+            MoELoadBalanceLossTracker.add(lb_loss)
+        return topk_idx, topk_weight
+
+
+# -----------------------------------------------------------------------------
+# MoE Block (the `mlp` attribute on the decoder layer)
+#
+# TODO_HF: match HF's MLP class name (e.g. `<Prefix>MLP`,
+# `<Prefix>MoEBlock`) and the attribute that holds the router
+# (`self.router` vs `self.gate` — follow HF).
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixMLP(nn.Module):  # TODO_HF rename to match HF
+    """MoE block with EP support."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        intermediate_size: int,
+        ep_size: int = 1,
+        ep_group: Optional[dist.ProcessGroup] = None,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+
+        # Protocol contract (DecoderLayerMlpProtocol):
+        self.ep_size = ep_size
+        self.ep_group = ep_group
+        self.ep_rank = ep_group.rank() if ep_group is not None else 0
+        self.experts_per_rank = num_experts // ep_size
+
+        self.experts = HFPrefixExperts(self.experts_per_rank, hidden_size, intermediate_size)
+        # TODO_HF: name this attribute per HF: self.router OR self.gate.
+        self.router = HFPrefixRouter(hidden_size, num_experts, num_experts_per_tok)
+
+        # TODO_HF (if applicable): self.shared_experts = <SharedMLP>(...)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Non-pipelined reference forward — used by reference_forward + test."""
+        orig_shape = hidden_states.shape
+        topk_idx, topk_weight = self.router(hidden_states)  # TODO_HF: .gate vs .router
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        y = self._moe_infer(hidden_states, topk_idx, topk_weight).view(*orig_shape)
+        return y
+
+    def _moe_infer(
+        self, x: torch.Tensor, topk_ids: torch.Tensor, topk_weight: torch.Tensor
+    ) -> torch.Tensor:
+        assert self.ep_size == 1, "Reference implementation only supports ep_size=1"
+        expert_idxs = topk_ids.view(-1)
+        sorted_tokens = (
+            x.unsqueeze(1).expand(-1, self.num_experts_per_tok, -1).reshape(-1, x.shape[-1])
+        )
+        output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks, ks_tensor = (
+            scatter_for_grouped_gemm(sorted_tokens, expert_idxs, self.experts_per_rank)
+        )
+        outs = self.experts(output_tokens, grouped_mm_offs, ks=ks, ks_tensor=ks_tensor)
+        outs = outs[reverse_shuffle_idxs]
+
+        final_out = (
+            (outs.view(*topk_ids.shape, -1) * topk_weight.unsqueeze(dim=-1))
+            .sum(dim=1)
+            .to(outs.dtype)
+        )
+        return final_out
+
+
+# -----------------------------------------------------------------------------
+# Attention
+#
+# TODO_HF: copy HF's attention class structure.  Pick the kernel that
+# matches HF's features:
+#   • Standard GQA / MHA, no sinks → flash_attn_func
+#   • Sliding window or sinks        → flex_attention (+ LSE renorm post-op)
+#   • Context parallelism needed     → ring_attention_func (conditional unwrap)
+#
+# DO NOT use `score_mod` closures that capture Parameters.  If HF does
+# something like "add a learned bias to attention scores", do it as a
+# post-op on the kernel output with the LSE trick — see reference/compile.md.
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixAttention(nn.Module):  # TODO_HF rename to match HF
+    """<one-line summary>."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        attention_bias: bool = False,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_attention_heads
+        self.num_kv_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.scaling = head_dim**-0.5
+
+        LinearCls = get_linear_cls()
+        self.q_proj = LinearCls(hidden_size, num_attention_heads * head_dim, bias=attention_bias)
+        self.k_proj = LinearCls(hidden_size, num_key_value_heads * head_dim, bias=attention_bias)
+        self.v_proj = LinearCls(hidden_size, num_key_value_heads * head_dim, bias=attention_bias)
+        self.o_proj = LinearCls(num_attention_heads * head_dim, hidden_size, bias=attention_bias)
+        # TODO_HF: add any model-specific Parameters (e.g. per-head sinks).
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        # TODO_HF: additional kwargs your kernel needs (block_mask, etc.)
+    ) -> torch.Tensor:
+        # TODO_HF: Q/K/V projection, RoPE, kernel call, o_proj.
+        raise NotImplementedError
+
+
+# -----------------------------------------------------------------------------
+# Decoder Layer — the 5-stage protocol surface.
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixDecoderLayer(nn.Module):  # TODO_HF rename to match HF
+    """Implements `DecoderLayerProtocol` (pithtrain/models/interface.py)."""
+
+    def __init__(
+        self,
+        # TODO_HF: the parameter list should reflect the HF config.
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        intermediate_size: int,
+        num_experts: int,
+        num_experts_per_tok: int,
+        rms_norm_eps: float,
+        attention_bias: bool,
+        layer_idx: int,
+        ep_size: int = 1,
+        ep_group: Optional[dist.ProcessGroup] = None,
+    ):
+        super().__init__()
+        self.idx = layer_idx  # protocol field — nvtx range labels use this
+        self.hidden_size = hidden_size
+
+        self.self_attn = HFPrefixAttention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            attention_bias=attention_bias,
+        )
+
+        self.mlp = HFPrefixMLP(
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            intermediate_size=intermediate_size,
+            ep_size=ep_size,
+            ep_group=ep_group,
+        )
+
+        self.input_layernorm = nn.RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(hidden_size, eps=rms_norm_eps)
+
+        # Conditional unwrap — only when a self-compiling attention kernel
+        # is active.  Leave this out if HF's attention doesn't need it.
+        # Example for ring attention:
+        #   if getattr(self.self_attn, "use_ring_attn", False):
+        #       self._forward_attn_compute = self._forward_attn_compute.__wrapped__.__get__(
+        #           self, type(self),
+        #       )
+
+    # ----- Stage 1 ---------------------------------------------------------
+    @torch.compile(fullgraph=True)
+    def _forward_attn_compute(self, hidden_states: torch.Tensor):
+        """LN + Attn + LN (+ shared experts if any).  Must be fullgraph-compilable.
+
+        NOTE: shared experts — if the model has them — are folded into
+        residual HERE, not in forward_aggregate.  Their compute overlaps
+        with the stage-2 all-to-all dispatch of the routed tokens.
+        """
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        position_embeddings = getattr(self, "_position_embeddings", None)
+        if position_embeddings is None:
+            raise RuntimeError("Position embeddings must be set before calling forward_attn")
+
+        hidden_states = self.self_attn(hidden_states, position_embeddings=position_embeddings)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+
+        # Shared-expert fold (keep this stanza; it's a no-op when no shared experts).
+        if hasattr(self.mlp, "shared_experts"):
+            residual = residual + self.mlp.shared_experts(hidden_states)
+
+        return hidden_states, residual
+
+    def forward_attn(self, hidden_states: torch.Tensor) -> ForwardAttnOutput:
+        hidden_states, residual = self._forward_attn_compute(hidden_states)
+
+        # TODO_HF (rare): dense fallback for non-MoE layers.  Most pure-MoE
+        # models don't need this; remove if every layer is MoE.
+        if not hasattr(self.mlp, "experts"):
+            return ForwardAttnOutput(
+                hidden_states,
+                None,
+                None,
+                None,
+                None,
+                None,
+                residual,
+            )
+
+        # Routing + dispatch prep
+        topk_ids, topk_weight = self.mlp.router(hidden_states)  # TODO_HF: .gate vs .router
+        (
+            sorted_tokens,
+            idxs,
+            expert_idxs,
+            expand_idx,
+            dedup_input_splits,
+            dedup_output_splits,
+            input_splits,
+            output_splits,
+        ) = moe_ep_prepare_dispatch(
+            hidden_states,
+            topk_ids,
+            self.mlp.num_experts,
+            self.mlp.ep_size,
+            self.mlp.experts_per_rank,
+            self.mlp.ep_group,
+        )
+        return ForwardAttnOutput(
+            sorted_tokens,
+            idxs,
+            topk_weight,
+            output_splits,
+            input_splits,
+            expert_idxs,
+            residual,
+            expand_idx,
+            dedup_input_splits,
+            dedup_output_splits,
+        )
+
+    # ----- Stage 3 ---------------------------------------------------------
+    def forward_mlp(
+        self,
+        gathered_tokens: torch.Tensor,
+        expert_idxs: Optional[torch.Tensor] = None,
+        expand_idx: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if not hasattr(self.mlp, "experts"):
+            assert expert_idxs is None
+            return self.mlp(gathered_tokens)
+
+        assert expert_idxs is not None
+        if expand_idx is not None:
+            # `padded_index_gather`, NOT raw gathered_tokens[expand_idx].
+            gathered_tokens = padded_index_gather(gathered_tokens, expand_idx)
+        output_tokens, reverse_shuffle_idxs, grouped_mm_offs, ks, ks_tensor = (
+            scatter_for_grouped_gemm(gathered_tokens, expert_idxs, self.mlp.experts_per_rank)
+        )
+        del gathered_tokens
+        outs = self.mlp.experts(output_tokens, grouped_mm_offs, ks=ks, ks_tensor=ks_tensor)
+        outs = padded_index_gather(outs, reverse_shuffle_idxs)
+        return outs
+
+    # ----- Stage 5 ---------------------------------------------------------
+    @torch.compile(fullgraph=True)
+    def forward_aggregate(
+        self,
+        moe_outs: torch.Tensor,
+        moe_local_idxs: Optional[torch.Tensor],
+        topk_weight: Optional[torch.Tensor],
+        residual: torch.Tensor,
+    ) -> torch.Tensor:
+        """Weighted expert sum + residual.  Shared experts are ALREADY folded into
+        residual inside `_forward_attn_compute` — do NOT re-add them here.
+        """
+        if hasattr(self.mlp, "experts"):
+            if self.mlp.ep_size > 1:
+                assert moe_local_idxs is not None
+                seq_len, topk = topk_weight.shape
+                permuted_probs = topk_weight.view(-1)[moe_local_idxs]
+                token_indices = moe_local_idxs // topk
+                weighted = (moe_outs.float() * permuted_probs.unsqueeze(-1)).to(moe_outs.dtype)
+                hidden_states = moe_outs.new_zeros(seq_len, moe_outs.shape[-1])
+                hidden_states.scatter_add_(0, token_indices[:, None].expand_as(weighted), weighted)
+                hidden_states = hidden_states.view(*residual.shape)
+            else:
+                assert moe_local_idxs is None
+                final_out = moe_outs.view(*topk_weight.shape, -1) * topk_weight.unsqueeze(-1)
+                hidden_states = final_out.sum(dim=1).to(moe_outs.dtype).view(*residual.shape)
+        else:
+            assert moe_local_idxs is None and topk_weight is None
+            hidden_states = moe_outs
+
+        return residual + hidden_states
+
+    # ----- Reference (non-pipelined) ---------------------------------------
+    def reference_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Plain forward — used by single-GPU test and the reference model in test_fsdp."""
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        position_embeddings = getattr(self, "_position_embeddings", None)
+        if position_embeddings is None:
+            raise RuntimeError("Position embeddings must be set before calling reference_forward")
+
+        # TODO_HF: if self_attn has a ring-attention path, disable it here (see
+        # Qwen3 / DeepSeek-V2 for the `_disable_ring_attn` flag pattern).
+        hidden_states = self.self_attn(hidden_states, position_embeddings=position_embeddings)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+# -----------------------------------------------------------------------------
+# Full Model — one pipeline stage of the model, wired for DualPipeV.
+# -----------------------------------------------------------------------------
+
+
+class HFPrefixModel(nn.Module):  # TODO_HF rename: typically `<Prefix>Model`
+    """<one-line summary>."""
+
+    def __init__(
+        self,
+        config,
+        num_stages: int,
+        stage_id: int,
+        cp_group: Optional[dist.ProcessGroup] = None,
+        ep_group: Optional[dist.ProcessGroup] = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.stage_id = stage_id
+        self.num_stages = num_stages
+
+        # TODO_HF: read fields off `config`.  Use `getattr(config, X, default)`
+        # for fields that are optional in HF's config.
+        hidden_size = config.hidden_size
+        num_attention_heads = config.num_attention_heads
+        num_key_value_heads = config.num_key_value_heads
+        head_dim = getattr(config, "head_dim", hidden_size // num_attention_heads)
+        intermediate_size = config.intermediate_size
+        num_experts = getattr(config, "num_local_experts", None) or config.num_experts
+        num_experts_per_tok = config.num_experts_per_tok
+        rms_norm_eps = config.rms_norm_eps
+        attention_bias = getattr(config, "attention_bias", False)
+        vocab_size = config.vocab_size
+        max_position_embeddings = config.max_position_embeddings
+        rope_theta = getattr(config, "rope_theta", 10000.0)
+
+        ep_size = getattr(config, "ep_size", 1)
+
+        # First stage has embed_tokens; last stage has norm + lm_head.
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size) if stage_id == 0 else None
+
+        num_local_layers = layer_partition(config.num_hidden_layers, num_stages)
+        layer_id_begin = sum(num_local_layers[:stage_id])
+        layer_id_end = layer_id_begin + num_local_layers[stage_id]
+
+        # nn.ModuleDict keyed by absolute layer_id string (required by FSDP wrapping).
+        self.layers = nn.ModuleDict(
+            {
+                str(i): HFPrefixDecoderLayer(
+                    hidden_size=hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    intermediate_size=intermediate_size,
+                    num_experts=num_experts,
+                    num_experts_per_tok=num_experts_per_tok,
+                    rms_norm_eps=rms_norm_eps,
+                    attention_bias=attention_bias,
+                    layer_idx=i,
+                    ep_size=ep_size,
+                    ep_group=ep_group,
+                )
+                for i in range(layer_id_begin, layer_id_end)
+            }
+        )
+
+        if stage_id == num_stages - 1:
+            self.norm = nn.RMSNorm(hidden_size, eps=rms_norm_eps)
+            self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+        else:
+            self.norm = None
+            self.lm_head = None
+
+        self.rotary_emb = HFPrefixRotaryEmbedding(
+            head_dim,
+            max_position_embeddings=max_position_embeddings,
+            base=rope_theta,
+        )
+
+        # TODO_HF: any other model-level state (e.g. block_mask cache for
+        # flex_attention).
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Forward pass.  Two modes:
+        • Plain (intermediate_tensors is None): reference / eager inference.
+        • Recorded (intermediate_tensors is set): the 5-stage path — we
+          must copy every stage record into the pre-allocated slot.
+        """
+        intermediate_tensors: Optional[IntermediateTensors] = getattr(
+            self, "_intermediate_tensors", None
+        )
+
+        if self.embed_tokens is not None:
+            input_ids = hidden_states
+            hidden_states = self.embed_tokens(input_ids)
+
+        bsz, seq_len, _ = hidden_states.shape
+
+        cos, sin = self.rotary_emb(hidden_states, seq_len=seq_len)
+        position_embeddings = (cos[:seq_len].unsqueeze(0), sin[:seq_len].unsqueeze(0))
+
+        for layer_idx_str, layer in self.layers.items():
+            layer._position_embeddings = position_embeddings
+            # TODO_HF: set any other per-forward state on layers here
+            # (e.g. layer._block_mask, layer type flags, etc.).
+
+        # Plain forward — falls into this branch under `reference_forward`
+        # and under plain eager inference.
+        if intermediate_tensors is None:
+            for _, layer in self.layers.items():
+                ret = decoder_layer_forward(layer, hidden_states)
+                hidden_states = ret[0] if isinstance(ret, tuple) else ret
+            if self.norm is not None:
+                hidden_states = self.norm(hidden_states)
+                hidden_states = self.lm_head(hidden_states)
+            return hidden_states
+
+        # Recorded forward — the 5-stage path.  The stage-record copy is
+        # critical: iterate EVERY field of every record, including stages
+        # 2 and 4 which only have `.ctx`.  See reference/protocol.md.
+        layer_idx = 0
+        if self.embed_tokens is not None:
+            intermediate_tensors.prolog.args = PrologArgs()
+            intermediate_tensors.prolog.outs = PrologOuts(hidden_states)
+
+        for _, layer in self.layers.items():
+            ret = decoder_layer_forward(layer, hidden_states)
+            if len(ret) == 2:
+                hidden_states, layer_record = ret
+                dst = intermediate_tensors.layers[layer_idx]
+                for field in fields(layer_record):
+                    src_rec = getattr(layer_record, field.name)
+                    dst_rec = getattr(dst, field.name)
+                    for rf in fields(src_rec):
+                        setattr(dst_rec, rf.name, getattr(src_rec, rf.name))
+            else:
+                hidden_states = ret[0]
+                dst = intermediate_tensors.layers[layer_idx]
+                for field in fields(dst):
+                    record = getattr(dst, field.name)
+                    for rf in fields(record):
+                        setattr(record, rf.name, None)
+            layer_idx += 1
+
+        if self.norm is not None:
+            assert self.lm_head is not None
+            if not ModelImplMode.use_reference_fwd:
+                hidden_states = hidden_states.detach().requires_grad_()
+            intermediate_tensors.epilog.args = EpilogArgs(hidden_states)
+            hidden_states = self.norm(hidden_states)
+            hidden_states = self.lm_head(hidden_states)
+
+        return hidden_states
+
+    @staticmethod
+    def backward(
+        module: "HFPrefixModel",
+        dy: Optional[List[torch.Tensor]],
+        loss: Optional[torch.Tensor],
+        intermediate_tensors: IntermediateTensors,
+    ):
+        """Backward pass.  Copy this verbatim; only the class name in
+        `module: "HFPrefixModel"` changes per model.
+        """
+        assert (dy is None) != (loss is None), "Either dy or loss should be provided"
+
+        if loss is not None:
+            assert module.norm is not None
+            assert module.lm_head is not None
+            loss.backward()
+            loss.detach_()
+            dy = (intermediate_tensors.epilog.args.hidden_states.grad,)
+            intermediate_tensors.epilog.args = None
+            loss = None
+        else:
+            assert module.norm is None
+            assert module.lm_head is None
+
+        dx = dy
+        layers_list = [layer for _, layer in module.layers.items()]
+        for layer, intermediate_tensors_layer in zip(
+            reversed(layers_list), reversed(intermediate_tensors.layers)
+        ):
+            dx = (decoder_layer_backward(layer, dx, loss, intermediate_tensors_layer),)
+
+        final_grads = dx
+        if module.embed_tokens is not None:
+            record = intermediate_tensors.prolog
+            run_backward(record.outs, dx)
+            for rf in fields(record):
+                setattr(record, rf.name, None)
+            final_grads = (None,)
+
+        return final_grads

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Templates that carry placeholder tokens (`<model>`, `<Model>Model`) are
+# not valid Python until filled in; skip them across all hooks.
+exclude: '^\.claude/skills/.+/templates/.+$'
+
 repos:
   # Basic file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
The add-new-model skill walks a developer through integrating a new MoE language model into PithTrain end to end: analyzing HuggingFace's reference implementation, writing the model file against the 5-stage DualPipeV protocol, wiring it into setup_model / apply_fsdp / test_fsdp, running the pp/ep scaling ladder from pp=1/ep=1 up to pp=2/ep=2, and (when needed) adding a checkpoint converter and an ad-hoc real-weight inference test.

Layout is a phase-gated SKILL.md entry point plus six reference docs (protocol, conventions, compile, checkpoint, testing, pitfalls) and two templates (a structural model skeleton and a DualPipeV inference harness). The reference docs are loaded on demand per phase to keep the entry point compact. Every pitfall learned from the gpt-oss bring-up - NaN-padding in grouped_mm, .view vs .transpose layout bugs, silent-zero experts from missing fill_weights branches, dynamic seq_len compile thrash - is encoded as a checklable rule.

The template files carry placeholder syntax (<Model>Model, <model>) that is not valid Python, so .pre-commit-config.yaml excludes .claude/skills/*/templates/ from every hook.