### PR TITLE
Fuse gpt-oss clamped SwiGLU into a Triton autograd op

### DIFF
--- a/pithtrain/models/gpt_oss.py
+++ b/pithtrain/models/gpt_oss.py
@@ -22,6 +22,7 @@ from pithtrain.dualpipe.utils import run_backward
 from pithtrain.layers.factory import ModelImplMode, get_linear_cls
 from pithtrain.models.interface import ForwardAttnOutput
 from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
+from pithtrain.operators.clamped_swiglu import clamped_swiglu
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
 from pithtrain.operators.token_scatter import padded_index_gather, scatter_for_grouped_gemm
 
@@ -210,13 +211,7 @@ class GptOssExperts(nn.Module):
 
         gate_up = self._grouped_mm(x, self.gate_up_proj, grouped_mm_offs)
         gate_up = gate_up + self.gate_up_proj_bias[group_ids]
-        gate = gate_up[:, ::2]
-        up = gate_up[:, 1::2]
-
-        gate = gate.clamp(max=self.swiglu_limit)
-        up = up.clamp(min=-self.swiglu_limit, max=self.swiglu_limit)
-        glu = gate * torch.sigmoid(SWIGLU_ALPHA * gate)
-        activated = (up + 1) * glu
+        activated = clamped_swiglu(gate_up, SWIGLU_ALPHA, self.swiglu_limit)
 
         out = self._grouped_mm(activated, self.down_proj, grouped_mm_offs)
         out = out + self.down_proj_bias[group_ids]

--- a/pithtrain/operators/clamped_swiglu.py
+++ b/pithtrain/operators/clamped_swiglu.py
@@ -1,0 +1,155 @@
+"""
+Fused clamped SwiGLU used in OpenAI's gpt-oss: ``(uc + 1) * gc * sigmoid(α·gc)``
+with ``gc = min(gate, L)`` and ``uc = clamp(up, ±L)``, where ``gate`` and
+``up`` are the even/odd columns of an interleaved ``gate_up [M, 2N]`` input.
+
+One Triton kernel each for forward and backward. Only ``gate_up`` is saved
+for backward; ``gc``, ``uc`` and the sigmoid are recomputed, and the clamp
+branches contribute zero gradient at saturation.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _clamped_swiglu_fwd_kernel(
+    gate_up_ptr,
+    out_ptr,
+    n_elements,
+    alpha,
+    limit,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # offs indexes the flat (M, N) output; interleaved gate_up pulls
+    # gate from 2*offs and up from 2*offs + 1.
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    gate = tl.load(gate_up_ptr + 2 * offs, mask=mask)
+    up = tl.load(gate_up_ptr + 2 * offs + 1, mask=mask)
+
+    g = gate.to(tl.float32)
+    u = up.to(tl.float32)
+
+    gc = tl.minimum(g, limit)
+    uc = tl.minimum(tl.maximum(u, -limit), limit)
+
+    sig = tl.sigmoid(alpha * gc)
+    glu = gc * sig
+    out = (uc + 1.0) * glu
+
+    tl.store(out_ptr + offs, out.to(gate.dtype), mask=mask)
+
+
+@triton.jit
+def _clamped_swiglu_bwd_kernel(
+    grad_out_ptr,
+    gate_up_ptr,
+    grad_gate_up_ptr,
+    n_elements,
+    alpha,
+    limit,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # grad_uc = do * glu
+    # grad_gc = do * (uc + 1) * σ * (1 + α * gc * (1 - σ))
+    # Clamp-aware: grad_g = grad_gc if g ≤ L else 0; grad_u = grad_uc if |u| ≤ L else 0.
+    block_start = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    do = tl.load(grad_out_ptr + offs, mask=mask)
+    gate = tl.load(gate_up_ptr + 2 * offs, mask=mask)
+    up = tl.load(gate_up_ptr + 2 * offs + 1, mask=mask)
+
+    do_f = do.to(tl.float32)
+    g = gate.to(tl.float32)
+    u = up.to(tl.float32)
+
+    gc = tl.minimum(g, limit)
+    uc = tl.minimum(tl.maximum(u, -limit), limit)
+
+    sig = tl.sigmoid(alpha * gc)
+    glu = gc * sig
+
+    grad_uc = do_f * glu
+    grad_gc = do_f * (uc + 1.0) * sig * (1.0 + alpha * gc * (1.0 - sig))
+
+    g_active = g <= limit
+    u_active = (u >= -limit) & (u <= limit)
+    grad_g = tl.where(g_active, grad_gc, 0.0)
+    grad_u = tl.where(u_active, grad_uc, 0.0)
+
+    tl.store(grad_gate_up_ptr + 2 * offs, grad_g.to(gate.dtype), mask=mask)
+    tl.store(grad_gate_up_ptr + 2 * offs + 1, grad_u.to(up.dtype), mask=mask)
+
+
+_BLOCK_SIZE = 1024
+
+
+class _ClampedSwiGLU(torch.autograd.Function):
+    """Fused clamped SwiGLU with a single-kernel backward."""
+
+    @staticmethod
+    def forward(ctx, gate_up: torch.Tensor, alpha: float, limit: float) -> torch.Tensor:
+        assert gate_up.dim() == 2, f"gate_up must be 2-D, got shape {gate_up.shape}"
+        M, two_n = gate_up.shape
+        assert two_n % 2 == 0, f"gate_up last dim must be even, got {two_n}"
+        assert gate_up.is_contiguous(), "gate_up must be contiguous"
+
+        N = two_n // 2
+        out = torch.empty((M, N), device=gate_up.device, dtype=gate_up.dtype)
+
+        ctx.save_for_backward(gate_up)
+        ctx.alpha = float(alpha)
+        ctx.limit = float(limit)
+
+        n = M * N
+        if n == 0:
+            return out
+
+        grid = (triton.cdiv(n, _BLOCK_SIZE),)
+        _clamped_swiglu_fwd_kernel[grid](
+            gate_up, out, n, ctx.alpha, ctx.limit, BLOCK_SIZE=_BLOCK_SIZE
+        )
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (gate_up,) = ctx.saved_tensors
+        assert grad_output.shape[0] == gate_up.shape[0]
+        assert grad_output.shape[1] * 2 == gate_up.shape[1]
+        assert grad_output.dtype == gate_up.dtype
+        assert grad_output.is_contiguous(), "grad_output must be contiguous"
+
+        grad_gate_up = torch.empty_like(gate_up)
+        n = grad_output.numel()
+        if n == 0:
+            return grad_gate_up, None, None
+
+        grid = (triton.cdiv(n, _BLOCK_SIZE),)
+        _clamped_swiglu_bwd_kernel[grid](
+            grad_output,
+            gate_up,
+            grad_gate_up,
+            n,
+            ctx.alpha,
+            ctx.limit,
+            BLOCK_SIZE=_BLOCK_SIZE,
+        )
+        return grad_gate_up, None, None
+
+
+def clamped_swiglu(gate_up: torch.Tensor, alpha: float, limit: float) -> torch.Tensor:
+    """Fused clamped SwiGLU with interleaved gate/up layout.
+
+    ``gate_up`` is ``(M, 2N)`` with gate at even columns and up at odd columns;
+    gate is clamped above at ``+limit``, up symmetrically to ``[-limit, +limit]``.
+    Returns ``(M, N)``.
+    """
+    return _ClampedSwiGLU.apply(gate_up, alpha, limit)

--- a/tests/test_clamped_swiglu.py
+++ b/tests/test_clamped_swiglu.py
@@ -1,0 +1,123 @@
+"""
+Correctness tests for the fused clamped-SwiGLU operator used in gpt-oss.
+"""
+
+import pytest
+import torch
+
+from pithtrain.operators.clamped_swiglu import clamped_swiglu
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+ALPHA = 1.702
+LIMIT = 7.0
+
+
+def _ref_forward(gate_up: torch.Tensor, alpha: float, limit: float) -> torch.Tensor:
+    gate = gate_up[:, ::2]
+    up = gate_up[:, 1::2]
+    gate_c = gate.clamp(max=limit)
+    up_c = up.clamp(min=-limit, max=limit)
+    glu = gate_c * torch.sigmoid(alpha * gate_c)
+    return (up_c + 1) * glu
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 2),
+        (128, 768),
+        (4096, 2048),
+        (8192, 4096),
+        (1023, 778),  # N odd, not a power of two
+        (37, 2050),  # M arbitrary, 2N not aligned to block
+    ],
+)
+def test_clamped_swiglu_forward_backward(shape, dtype):
+    torch.manual_seed(0)
+    device = "cuda"
+
+    M, two_n = shape
+    assert two_n % 2 == 0, "test shapes must have even last dim"
+
+    # Sample a mix of in-range and saturating values so the clamp branch is
+    # exercised on both signs of ``up`` and the upper bound of ``gate``.
+    gate_up_ref = (torch.randn(M, two_n, device=device, dtype=dtype) * 4.0).requires_grad_()
+    gate_up = gate_up_ref.detach().clone().requires_grad_()
+
+    out_ref = _ref_forward(gate_up_ref, ALPHA, LIMIT)
+    out = clamped_swiglu(gate_up, ALPHA, LIMIT)
+
+    # bf16/fp16 store each intermediate rounded; our fused kernel keeps
+    # everything in fp32 until the final store, so it is strictly *more*
+    # accurate than the reference — loosen tolerance for the reference's noise.
+    atol, rtol = (5e-2, 1e-2) if dtype == torch.float16 else (3e-1, 5e-2)
+    torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+    out_ref.backward(grad_out)
+
+    torch.testing.assert_close(gate_up.grad, gate_up_ref.grad, atol=atol, rtol=rtol)
+
+
+@requires_cuda
+def test_clamped_swiglu_saturated_gradient_is_zero():
+    """Values strictly outside [-limit, limit] must produce zero gradient.
+
+    Clamp's chain-rule is zero once we leave the feasible region, so any
+    implementation that drops the mask (e.g. treating ``clamp`` as identity
+    in backward) will fail this test.
+    """
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.float32
+
+    M, N = 8, 16
+    two_n = 2 * N
+    gate_up = torch.empty(M, two_n, device=device, dtype=dtype)
+
+    # Gate even columns, up odd columns.
+    gate_vals = torch.linspace(-LIMIT - 4.0, LIMIT + 4.0, M * N, device=device).view(M, N)
+    up_vals = torch.linspace(LIMIT + 3.0, LIMIT + 5.0, M * N, device=device).view(M, N)
+    gate_up[:, ::2] = gate_vals
+    gate_up[:, 1::2] = up_vals
+    gate_up.requires_grad_()
+
+    out = clamped_swiglu(gate_up, ALPHA, LIMIT)
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+
+    grad_gate = gate_up.grad[:, ::2]
+    grad_up = gate_up.grad[:, 1::2]
+
+    # Gate: one-sided saturation. g > LIMIT ⇒ grad_g == 0.
+    saturated_gate = gate_vals > LIMIT
+    assert torch.all(grad_gate[saturated_gate] == 0)
+
+    # Up: every up_val > LIMIT here, so every grad_up cell must be zero.
+    assert torch.all(grad_up == 0)
+
+
+@requires_cuda
+def test_clamped_swiglu_matches_hf_reference_shape():
+    """Smoke test using gpt-oss-20b-like dims: 32 experts × 768-width tile."""
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Realistic per-expert token count and intermediate_size.
+    M, intermediate = 4096, 2880
+    gate_up_ref = torch.randn(M, 2 * intermediate, device=device, dtype=dtype).requires_grad_()
+    gate_up = gate_up_ref.detach().clone().requires_grad_()
+
+    out_ref = _ref_forward(gate_up_ref, ALPHA, LIMIT)
+    out = clamped_swiglu(gate_up, ALPHA, LIMIT)
+    torch.testing.assert_close(out, out_ref, atol=3e-1, rtol=5e-2)
+
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+    out_ref.backward(grad_out)
+    torch.testing.assert_close(gate_up.grad, gate_up_ref.grad, atol=3e-1, rtol=5e-2)


### PR DESCRIPTION
Replaces the eager split/clamp/sigmoid/mul/add chain in GptOssExperts with a single forward + single backward Triton kernel. The fused op reads the interleaved gate_up [M, 2N] via strided loads, applies gate=min(g, L) and up=clamp(u, +/-L), and emits (uc+1) * gc * sigmoid(alpha*gc). Backward saves only gate_up, recomputing gc, uc and the sigmoid on the fly, and zeroes the gradient through saturated clamp branches (matching TransformerEngine's clamped_dswiglu; Megatron's fused_bias_geglu keeps clamp outside the fused region and drops this mask).

Net effect: one kernel launch per direction instead of ~6, and saved activations drop from gate_up + sigmoid/glu/up_clamped intermediates to just gate_up. Unit tests cover both signs of up, the gate upper bound, and strictly-saturated inputs to catch a clamp-unaware backward.