### PR TITLE
Add wgrad-delay support to BF16 GroupLinear for DualPipeV

### DIFF
--- a/pithtrain/layers/group_linear.py
+++ b/pithtrain/layers/group_linear.py
@@ -1,8 +1,51 @@
+from functools import partial
 from typing import Optional
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from pithtrain.dualpipe.utils import WeightGradStore
+
+
+class GroupLinearFunc(torch.autograd.Function):
+    """
+    Custom autograd Function for BF16 grouped linear layer (MoE experts).
+
+    Forward: output      = grouped_mm(input, weight.T)      [2D-3D, jagged on M]
+    Dgrad:   grad_input  = grouped_mm(grad_output, weight)  [2D-3D, jagged on M]
+    Wgrad:   weight_grad = grouped_mm(grad_output.T, input) [2D-2D, jagged on K]
+
+    The wgrad is split from dgrad so DualPipeV's zero-bubble W-phase can defer
+    it via WeightGradStore, freeing the critical path during stage3_b.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        grouped_mm_offs: torch.Tensor,
+    ) -> torch.Tensor:
+        output = F.grouped_mm(input, weight.transpose(1, 2), offs=grouped_mm_offs)
+        ctx.save_for_backward(input, weight, grouped_mm_offs)
+        return output
+
+    @staticmethod
+    def backward(ctx, dy):
+        input, weight, offs = ctx.saved_tensors
+        dgrad = F.grouped_mm(dy, weight, offs=offs)
+
+        def wgrad_fn(dy, x, offs):
+            wgrad = F.grouped_mm(dy.transpose(0, 1), x, offs=offs)
+            weight.grad = wgrad if weight.grad is None else weight.grad.add_(wgrad)
+
+        if WeightGradStore.enabled:
+            WeightGradStore.put(partial(wgrad_fn, dy.detach(), input.detach(), offs.detach()))
+        else:
+            wgrad_fn(dy, input, offs)
+
+        return dgrad, None, None
 
 
 class GroupLinear(nn.Module):
@@ -32,4 +75,4 @@ class GroupLinear(nn.Module):
             # With 0 tokens the result is (0, out_features) and gradients are zero,
             # but the grad_fn must exist so that run_backward does not crash.
             return input @ self.weight[0].T
-        return F.grouped_mm(input, self.weight.transpose(1, 2), offs=grouped_mm_offs)
+        return GroupLinearFunc.apply(input, self.weight, grouped_mm_offs)

--- a/tests/test_grouped_linear_correctness.py
+++ b/tests/test_grouped_linear_correctness.py
@@ -579,3 +579,58 @@ def test_scatter_then_grouped_mm_end_to_end():
         assert torch.allclose(result, result_ref, rtol=1e-4, atol=1e-4), (
             f"End-to-end mismatch for '{test_name}'! Max diff: {max_diff}"
         )
+
+
+def test_group_linear_weight_grad_store():
+    """GroupLinear correctly defers weight gradients via WeightGradStore."""
+    from pithtrain.dualpipe.utils import WeightGradStore
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    num_groups, in_features, out_features = 4, 128, 256
+    group_sizes = [16, 8, 12, 4]
+    M_total = sum(group_sizes)
+    grouped_mm_offs = torch.tensor(group_sizes, device=device).cumsum(0).to(torch.int32)
+
+    gl_ref = GroupLinear(num_groups, in_features, out_features).to(device).to(dtype)
+    torch.nn.init.normal_(gl_ref.weight, std=0.02)
+
+    x_raw = torch.randn(M_total, in_features, device=device, dtype=dtype)
+    grad = torch.randn(M_total, out_features, device=device, dtype=dtype)
+
+    # Reference: no WeightGradStore.
+    x_ref = x_raw.detach().clone().requires_grad_(True)
+    gl_ref(x_ref, grouped_mm_offs).backward(grad)
+    ref_weight_grad = gl_ref.weight.grad.clone()
+    ref_input_grad = x_ref.grad.clone()
+
+    # Deferred path.
+    gl = GroupLinear(num_groups, in_features, out_features).to(device).to(dtype)
+    gl.weight.data.copy_(gl_ref.weight.data)
+    x_def = x_raw.detach().clone().requires_grad_(True)
+
+    WeightGradStore.enabled = True
+    try:
+        gl(x_def, grouped_mm_offs).backward(grad)
+
+        assert gl.weight.grad is None, "Weight grad should be deferred"
+        assert x_def.grad is not None, "Input grad should be on the critical path"
+
+        input_diff = (x_def.grad - ref_input_grad).abs().max().item()
+        assert torch.allclose(x_def.grad, ref_input_grad, rtol=1e-3, atol=1e-3), (
+            f"Input grad diff = {input_diff}"
+        )
+
+        WeightGradStore.flush()
+        WeightGradStore.pop()
+
+        assert gl.weight.grad is not None, "Weight grad should exist after pop"
+        assert gl.weight.grad.shape == gl.weight.shape
+        weight_diff = (gl.weight.grad - ref_weight_grad).abs().max().item()
+        assert torch.allclose(gl.weight.grad, ref_weight_grad, rtol=1e-3, atol=1e-3), (
+            f"Deferred vs direct weight grad diff = {weight_diff}"
+        )
+    finally:
+        WeightGradStore.enabled = False
+        WeightGradStore.clear()


### PR DESCRIPTION
Thanks the following Claude skills, we can gather the insights autonomously.

## validate-correctness

### deepseek-v2-lite, PP2-EP2

- Model: deepseek-v2-lite, mesh: PP=2 × EP=2 × DP=2 (1 node, 8 GPUs)
- Base: origin/main (fff4576) · Feature: 0419-delay-wgrad (39ddc4a)
- Max cross-entropy rel_diff: 1.16e-3 (step 21), under threshold                                                                                           
- Max load-balance-loss rel_diff: 9.47e-4 (step 19), under threshold
- Performance: step-time −1.19% (25.16s → 24.86s), peak memory −0.01% (66.19 GB → 66.19 GB)                                                                 

### qwen3-30b-a3b, PP2-EP8

- Model: qwen3-30b-a3b, mesh: PP=2 × EP=8 × DP=1 (2 nodes, 16 GPUs)
- Base: origin/main (fff4576) · Feature: 0419-delay-wgrad (39ddc4a)
- Max cross-entropy rel_diff: 2.69e-4 (step 25), under threshold
- Max load-balance-loss rel_diff: 1.36e-4 (step 24), under threshold
- Performance: step-time −2.63% (21.77s → 21.20s), peak memory −5.78% (58.54 GB → 55.16 GB)

## capture-nsys-profile

### qwen3-30b-a3b, PP2-EP8, Base (fff4576)

stage3_b + stage2_f + stage2_b + stage3_w + stage3_f -> 2.507ms

<img width="2061" height="920" alt="image" src="https://github.com/user-attachments/assets/258525c5-9a2a-44f1-93d4-4f30ad57b8ab" />

### qwen3-30b-a3b, PP2-EP8, Feature (39ddc4a)

stage3_b + stage2_f + stage2_b + stage3_w + stage3_f -> 2.461ms

<img width="2061" height="920" alt="image" src="https://github.com/user-attachments/assets/38621095-4371-4bf2-83a0-6d71fae0d70f" />

---

And yes, still some manual testing in this agentic era :-)

## manual unittest

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0 -- /home/haok/Pith-Train/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/haok/Pith-Train
configfile: pyproject.toml
plugins: anyio-4.13.0
collecting ... collected 1 item

tests/test_grouped_linear_correctness.py::test_group_linear_weight_grad_store PASSED

============================== 1 passed in 4.32s ===============================
```