### PR TITLE
Fail fast on rank failure to avoid torchrun shutdown hangs

### DIFF
--- a/pithtrain/modules/distributed.py
+++ b/pithtrain/modules/distributed.py
@@ -4,11 +4,13 @@ import atexit
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Generator
 
 import torch
 
 from pithtrain.config import SlottedDefault
+from pithtrain.modules import shutdown
 
 
 @dataclass(init=False, slots=True)
@@ -111,7 +113,11 @@ def setup_default_process_group(cfg: DistributedCfg, ctx: DistributedCtx) -> Non
     kwargs = dict()
     kwargs["backend"] = "nccl"
     kwargs["device_id"] = ctx.local_rank
+    # NCCL default per-collective timeout is 30 min; cap at 3 to bound worst-case hangs.
+    kwargs["timeout"] = timedelta(seconds=180)
     torch.distributed.init_process_group(**kwargs)
+    # See pithtrain.modules.shutdown for why os._exit(1), not destroy/abort.
+    shutdown.install_failfast_excepthook()
     atexit.register(torch.distributed.destroy_process_group)
     torch.cuda.set_device(ctx.local_rank)
 

--- a/pithtrain/modules/shutdown.py
+++ b/pithtrain/modules/shutdown.py
@@ -1,0 +1,53 @@
+"""Fast-fail shutdown when any rank raises.
+
+Default torch.distributed shutdown can hang indefinitely: atexit
+destroy_process_group drains in-flight NCCL work that peers will never
+satisfy, so the failing rank hangs in atexit, torchrun never sees the
+death, and peers spin until something external kills the job.
+
+_abort_process_group has the same drain-deadlock in NCCL 2.28 (despite
+docs claiming non-blocking). The only escape is os._exit(1) from a
+sys.excepthook -- the kernel reaps FDs/sockets/CUDA IPC, peers' NCCL
+ops fail in milliseconds, and torchrun SIGTERMs the rest.
+"""
+
+import os
+import sys
+import threading
+
+import torch  # noqa: F401
+from torch.distributed.elastic.multiprocessing.errors import record  # noqa: F401
+
+
+def set_env_defaults() -> None:
+    """NCCL env defaults that bound failure detection. Must run before init."""
+    os.environ.setdefault("TORCH_NCCL_ASYNC_ERROR_HANDLING", "1")
+    os.environ.setdefault("TORCH_NCCL_BLOCKING_WAIT", "0")
+    os.environ.setdefault("TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC", "180")
+    os.environ.setdefault("TORCH_NCCL_DUMP_ON_TIMEOUT", "1")
+
+
+def install_failfast_excepthook() -> None:
+    """On uncaught exception: print, flush, os._exit(1) -- no abort/destroy."""
+    prev = sys.excepthook
+
+    def hook(exc_type, exc_value, exc_tb):
+        try:
+            prev(exc_type, exc_value, exc_tb)
+        except Exception:
+            pass
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        # No abort/destroy: both block on the drain we're escaping.
+        os._exit(1)
+
+    sys.excepthook = hook
+    # Background threads (e.g. logging workers) would otherwise just print and
+    # let the main thread continue into the next collective and hang.
+    threading.excepthook = lambda args: hook(args.exc_type, args.exc_value, args.exc_traceback)
+
+
+set_env_defaults()

--- a/pithtrain/tasks/pretrain_language_model.py
+++ b/pithtrain/tasks/pretrain_language_model.py
@@ -25,6 +25,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
 from pithtrain.config import SlottedDefault
+from pithtrain.modules import shutdown
 from pithtrain.modules.checkpoint import (
     to_canonical_model,
     to_canonical_optim,
@@ -472,6 +473,7 @@ def train_step(cfg: PretrainLanguageModelCfg, ctx: PretrainLanguageModelCtx) -> 
     gc.collect()
 
 
+@shutdown.record
 def launch(cfg: PretrainLanguageModelCfg) -> None:
     """Launch the pretraining of a language model."""
     with ExitStack() as stack:

--- a/tests/test_fsdp.py
+++ b/tests/test_fsdp.py
@@ -21,6 +21,7 @@ from pithtrain.layers.group_linear import GroupLinear
 from pithtrain.models.deepseek_v2_lite import DeepseekV2LiteModel, DeepseekV2LiteMoEGate
 from pithtrain.models.gpt_oss import GptOssExperts, GptOssModel, GptOssTopKRouter
 from pithtrain.models.qwen3_30b_a3b import Qwen3MoeGate, Qwen3MoeModel
+from pithtrain.modules import shutdown
 from pithtrain.modules.distributed import DistributedCfg, DistributedCtx, distributed_context
 
 
@@ -377,7 +378,8 @@ def main(ctx: DistributedCtx, model_name: str):
     torch.distributed.barrier()
 
 
-if __name__ == "__main__":
+@shutdown.record
+def _entry() -> None:
     models = []
     models.append("examples/pretrain_language_model/deepseek-v2-lite/config.json")
     models.append("examples/pretrain_language_model/qwen3-30b-a3b/config.json")
@@ -398,3 +400,7 @@ if __name__ == "__main__":
 
     with distributed_context(cfg, ctx):
         main(ctx.distributed, parsed.model)
+
+
+if __name__ == "__main__":
+    _entry()

--- a/tests/test_fsdp.sh
+++ b/tests/test_fsdp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Test FSDP with DualPipeV.
 
-set -eu
+set -euo pipefail
 
 export WORKSPACE=$(readlink -f ${WORKSPACE:-$PWD/workspace})
 export OMP_NUM_THREADS=8


### PR DESCRIPTION
When a rank raises mid-step, the default atexit destroy_process_group drains in-flight NCCL work that peers will never satisfy, so the failing rank hangs in atexit forever, torchrun's agent never observes the death, and the whole job sits idle until something external kills it. _abort_process_group exhibits the same drain-deadlock in NCCL 2.28 despite docs claiming it is non-blocking.

Add pithtrain.modules.shutdown with a sys.excepthook that prints the traceback and then os._exit(1) directly -- skipping atexit, abort, and destroy alike. The kernel reaps FDs, sockets, and CUDA IPC handles, so peers' NCCL ops error within milliseconds and torchrun's agent SIGTERMs the rest. Also set NCCL env defaults (async error handling, 180s heartbeat / per-collective timeout, dump on timeout) and decorate the training/test entrypoints with @record so torchrun's failure summary includes the rank's traceback instead of <N/A>.

Validated on a 4-GPU deadlock-shaped repro: stock pithtrain hung 5+ min (killed by outer timeout); with the fix it exits in 11.6s with the full traceback. test_fsdp on qwen3-30b-a3b still passes (41s, gradients match reference). Switch test_fsdp.sh to set -euo pipefail so torchrun's non-zero exit isn't swallowed by tee.