### PR TITLE
Speed up GPT-OSS: FA-4 attention + Triton bias-grad kernel

### DIFF
--- a/pithtrain/models/gpt_oss.py
+++ b/pithtrain/models/gpt_oss.py
@@ -2,18 +2,13 @@
 
 import math
 from dataclasses import fields
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from flash_attn.cute.interface import flash_attn_func
 from torch import nn
-from torch.nn.attention.flex_attention import (
-    AuxRequest,
-    BlockMask,
-    create_block_mask,
-    flex_attention,
-)
 
 from pithtrain.dualpipe.execution import EpilogArgs, IntermediateTensors, PrologArgs, PrologOuts
 from pithtrain.dualpipe.layer_partition import layer_partition
@@ -27,6 +22,7 @@ from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBa
 from pithtrain.operators.clamped_swiglu import clamped_swiglu
 from pithtrain.operators.deepgemm_fp8_quantize import fused_blockwise_transpose_cast_to_fp8_batched
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
+from pithtrain.operators.indexed_bias_add import indexed_bias_add
 from pithtrain.operators.token_scatter import (
     padded_index_gather,
     precompute_group_indices,
@@ -261,13 +257,13 @@ class GptOssExperts(nn.Module):
         gate_up = self._group_linear(
             x, self.gate_up_proj, "gate_up_proj", grouped_mm_offs, ks, ks_tensor, gi
         )
-        gate_up = gate_up + self.gate_up_proj_bias[group_ids]
+        gate_up = indexed_bias_add(gate_up, self.gate_up_proj_bias, group_ids, grouped_mm_offs)
         activated = clamped_swiglu(gate_up, SWIGLU_ALPHA, self.swiglu_limit)
 
         out = self._group_linear(
             activated, self.down_proj, "down_proj", grouped_mm_offs, ks, ks_tensor, gi
         )
-        out = out + self.down_proj_bias[group_ids]
+        out = indexed_bias_add(out, self.down_proj_bias, group_ids, grouped_mm_offs)
         return out
 
 
@@ -391,13 +387,11 @@ class GptOssAttention(nn.Module):
     """
     Grouped Query Attention with attention sinks and optional sliding window.
 
-    Attention sinks are a learned per-head scalar added to the softmax
-    denominator.  We apply them as a post-hoc LSE renormalisation on the
-    flex_attention output rather than via a ``score_mod`` closure, so that
-    the surrounding ``_forward_attn_compute`` stays ``@torch.compile(fullgraph=True)``
-    traceable.  Large sink values let a head "dump" attention mass to the
-    sink, producing near-zero attention to real tokens.  See the forward
-    method for the renorm math.
+    Backed by FlashAttention-4 (CUTE DSL).  learnable_sink is a per-head
+    scalar fused into the softmax denominator inside the kernel — letting a
+    head "dump" attention mass to the sink and produce near-zero attention to
+    real tokens.  Causal + sliding window + GQA + per-head sink are all
+    native kwargs, so attention runs in a single FA-4 kernel call.
     """
 
     def __init__(
@@ -407,6 +401,8 @@ class GptOssAttention(nn.Module):
         num_key_value_heads: int,
         head_dim: int,
         attention_bias: bool = True,
+        is_sliding: bool = False,
+        sliding_window: int = 128,
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -414,6 +410,8 @@ class GptOssAttention(nn.Module):
         self.num_kv_heads = num_key_value_heads
         self.head_dim = head_dim
         self.scaling = head_dim**-0.5
+        self.is_sliding = is_sliding
+        self.sliding_window = sliding_window
 
         LinearCls = get_linear_cls()
         self.q_proj = LinearCls(hidden_size, num_attention_heads * head_dim, bias=attention_bias)
@@ -427,7 +425,6 @@ class GptOssAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        block_mask: BlockMask,
     ) -> torch.Tensor:
         bsz, seq_len, _ = hidden_states.size()
 
@@ -440,34 +437,26 @@ class GptOssAttention(nn.Module):
         cos, sin = position_embeddings
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-        query_states = query_states.transpose(1, 2)
-        key_states = key_states.transpose(1, 2)
-        value_states = value_states.transpose(1, 2)
-
-        # Attention sinks via post-hoc LSE renormalisation (HF / TorchTitan
-        # recipe).  The alternative - a score_mod closure over self.sinks with
-        # a virtual zero-valued KV row - forces flex_attention to self-compile
-        # and prevents the outer @torch.compile(fullgraph=True) from tracing
-        # through, which leaves the whole attention block in eager mode.  The
-        # renormalisation here is mathematically identical:
-        #   softmax_with_sink(s)_i = exp(s_i) / (sum_j exp(s_j) + exp(sink))
-        #                          = softmax(s)_i * sigmoid(lse - sink)
-        attn_output, aux = flex_attention(
+        # FA-4 expects (B, S, H, D); GQA is auto-detected from H_q vs H_kv.
+        # Sliding window: (W-1, 0) means each query attends to W tokens (self
+        # + W-1 prior).
+        window_size: Tuple[Optional[int], Optional[int]] = (
+            (self.sliding_window - 1, 0) if self.is_sliding else (None, None)
+        )
+        # FA-4 requires learnable_sink to match q/k/v dtype; the parameter
+        # itself stays in fp32 for optimizer numerical stability.
+        # flash_attn_func returns (out, lse); we only need out.
+        attn_output, _ = flash_attn_func(
             query_states,
             key_states,
             value_states,
-            block_mask=block_mask,
-            scale=self.scaling,
-            enable_gqa=True,
-            return_aux=AuxRequest(lse=True),
+            softmax_scale=self.scaling,
+            causal=True,
+            window_size=window_size,
+            learnable_sink=self.sinks.to(query_states.dtype),
         )
-        lse = aux.lse
-        sink_scale = torch.sigmoid(lse - self.sinks.float().view(1, -1, 1))
-        attn_output = attn_output * sink_scale.to(attn_output.dtype).unsqueeze(-1)
 
-        attn_output = attn_output.transpose(1, 2).reshape(
-            bsz, seq_len, self.num_heads * self.head_dim
-        )
+        attn_output = attn_output.reshape(bsz, seq_len, self.num_heads * self.head_dim)
         attn_output = self.o_proj(attn_output)
         return attn_output
 
@@ -493,6 +482,8 @@ class GptOssDecoderLayer(nn.Module):
         rms_norm_eps: float,
         attention_bias: bool,
         layer_idx: int,
+        is_sliding: bool = False,
+        sliding_window: int = 128,
         ep_size: int = 1,
         ep_group: Optional[dist.ProcessGroup] = None,
     ):
@@ -506,6 +497,8 @@ class GptOssDecoderLayer(nn.Module):
             num_key_value_heads=num_key_value_heads,
             head_dim=head_dim,
             attention_bias=attention_bias,
+            is_sliding=is_sliding,
+            sliding_window=sliding_window,
         )
 
         self.mlp = GptOssMLP(
@@ -521,7 +514,6 @@ class GptOssDecoderLayer(nn.Module):
         self.input_layernorm = nn.RMSNorm(hidden_size, eps=rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(hidden_size, eps=rms_norm_eps)
 
-    @torch.compile(fullgraph=True)
     def _forward_attn_compute(self, hidden_states: torch.Tensor):
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
@@ -529,14 +521,10 @@ class GptOssDecoderLayer(nn.Module):
         position_embeddings = getattr(self, "_position_embeddings", None)
         if position_embeddings is None:
             raise RuntimeError("Position embeddings must be set before calling forward_attn")
-        block_mask = getattr(self, "_block_mask", None)
-        if block_mask is None:
-            raise RuntimeError("Block mask must be set before calling forward_attn")
 
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
-            block_mask=block_mask,
         )
         hidden_states = residual + hidden_states
 
@@ -631,14 +619,10 @@ class GptOssDecoderLayer(nn.Module):
         position_embeddings = getattr(self, "_position_embeddings", None)
         if position_embeddings is None:
             raise RuntimeError("Position embeddings must be set before calling reference_forward")
-        block_mask = getattr(self, "_block_mask", None)
-        if block_mask is None:
-            raise RuntimeError("Block mask must be set before calling reference_forward")
 
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
-            block_mask=block_mask,
         )
         hidden_states = residual + hidden_states
 
@@ -653,20 +637,6 @@ class GptOssDecoderLayer(nn.Module):
 # ---------------------------------------------------------------------------
 # Full Model
 # ---------------------------------------------------------------------------
-
-
-def _make_causal_mask():
-    def mask_mod(b, h, q_idx, kv_idx):
-        return kv_idx <= q_idx
-
-    return mask_mod
-
-
-def _make_sliding_mask(window_size: int):
-    def mask_mod(b, h, q_idx, kv_idx):
-        return (q_idx >= kv_idx) & (q_idx - kv_idx < window_size)
-
-    return mask_mod
 
 
 class GptOssModel(nn.Module):
@@ -735,6 +705,8 @@ class GptOssModel(nn.Module):
                     rms_norm_eps=rms_norm_eps,
                     attention_bias=attention_bias,
                     layer_idx=i,
+                    is_sliding=(layer_types[i] == "sliding_attention"),
+                    sliding_window=sliding_window,
                     ep_size=ep_size,
                     ep_group=ep_group,
                 )
@@ -762,29 +734,6 @@ class GptOssModel(nn.Module):
             truncate=bool(rope_scaling.get("truncate", False)),
         )
 
-        self._block_mask_cache: Dict[int, Tuple[BlockMask, BlockMask]] = {}
-
-    def _get_block_masks(self, seq_len: int, device: torch.device) -> Tuple[BlockMask, BlockMask]:
-        if seq_len not in self._block_mask_cache:
-            causal_mask = create_block_mask(
-                _make_causal_mask(),
-                B=None,
-                H=None,
-                Q_LEN=seq_len,
-                KV_LEN=seq_len,
-                device=device,
-            )
-            sliding_mask = create_block_mask(
-                _make_sliding_mask(self.sliding_window),
-                B=None,
-                H=None,
-                Q_LEN=seq_len,
-                KV_LEN=seq_len,
-                device=device,
-            )
-            self._block_mask_cache[seq_len] = (causal_mask, sliding_mask)
-        return self._block_mask_cache[seq_len]
-
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         intermediate_tensors: Optional[IntermediateTensors] = getattr(
             self, "_intermediate_tensors", None
@@ -802,12 +751,8 @@ class GptOssModel(nn.Module):
             sin[:seq_len].unsqueeze(0),
         )
 
-        causal_mask, sliding_mask = self._get_block_masks(seq_len, hidden_states.device)
-
-        for layer_idx_str, layer in self.layers.items():
+        for layer in self.layers.values():
             layer._position_embeddings = position_embeddings
-            layer_type = self.layer_types[int(layer_idx_str)]
-            layer._block_mask = sliding_mask if layer_type == "sliding_attention" else causal_mask
 
         if intermediate_tensors is None:
             for _, layer in self.layers.items():

--- a/pithtrain/operators/indexed_bias_add.py
+++ b/pithtrain/operators/indexed_bias_add.py
@@ -1,0 +1,127 @@
+"""
+x + bias[group_ids] with a fast segmented-reduction backward for the
+common MoE pattern where tokens have already been sorted by destination
+expert (so group_ids is non-decreasing and each group is a contiguous
+range of rows [grouped_mm_offs[g-1], grouped_mm_offs[g])).
+
+Autograd's default bias[group_ids] backward lowers to index_put_ with
+bf16 atomic adds on bias rows — for GPT-OSS expert biases that's the
+single dominant kernel by a wide margin (~48% of GPU time, vs <2% for
+the actual expert GEMMs).  We replace it with a Triton-fused per-group
+reduction (one block per (group, h-tile)) that is fully parallel and
+atomic-free.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _segment_sum_kernel(
+    x_ptr,
+    offs_padded_ptr,
+    out_ptr,
+    H: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """
+    One block reduces rows [start, end) of group g for a HEAD_BLOCK-wide
+    slab of the hidden dim.  Accumulation is in fp32 for numerical
+    stability; the cast back to the source dtype happens at the call site.
+    """
+    g = tl.program_id(0)
+    h_blk = tl.program_id(1)
+
+    start = tl.load(offs_padded_ptr + g)
+    end = tl.load(offs_padded_ptr + g + 1)
+
+    h_offs = h_blk * HEAD_BLOCK + tl.arange(0, HEAD_BLOCK)
+    h_mask = h_offs < H
+
+    acc = tl.zeros((HEAD_BLOCK,), dtype=tl.float32)
+    for m_start in tl.range(start, end, BLOCK_M):
+        m_offs = m_start + tl.arange(0, BLOCK_M)
+        m_mask = m_offs < end
+        ptrs = x_ptr + m_offs[:, None] * H + h_offs[None, :]
+        x = tl.load(ptrs, mask=m_mask[:, None] & h_mask[None, :], other=0.0).to(tl.float32)
+        acc += tl.sum(x, axis=0)
+
+    tl.store(out_ptr + g * H + h_offs, acc, mask=h_mask)
+
+
+def _segment_sum_along_rows(
+    x: torch.Tensor,
+    grouped_mm_offs: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """
+    Per-group sum over rows.  Tokens are assumed already sorted by group.
+
+    Parameters:
+        x: (M, H) contiguous tensor.
+        grouped_mm_offs: (E,) cumulative end-offsets per group (group g
+            spans rows [offs[g-1], offs[g]) with offs[-1] := 0).
+        out_dtype: dtype of the returned bias gradient (matches the bias
+            parameter's dtype).
+
+    Returns:
+        (E, H) tensor where row g holds the sum of x rows in group g.
+    """
+    assert x.is_contiguous(), "x must be contiguous"
+    M, H = x.shape
+    E = grouped_mm_offs.shape[0]
+
+    # Prepend zero so each block can read both [start, end) without a branch.
+    offs_padded = torch.empty(E + 1, dtype=torch.int32, device=x.device)
+    offs_padded[0] = 0
+    # .clamp keeps padding-rows out of the reduction if grouped_mm_offs
+    # exceeds M; copy into int32 once.
+    offs_padded[1:].copy_(grouped_mm_offs.to(torch.int32).clamp(max=M))
+
+    out = torch.empty((E, H), dtype=torch.float32, device=x.device)
+
+    HEAD_BLOCK = 128
+    BLOCK_M = 128
+    grid = (E, triton.cdiv(H, HEAD_BLOCK))
+    _segment_sum_kernel[grid](
+        x,
+        offs_padded,
+        out,
+        H=H,
+        HEAD_BLOCK=HEAD_BLOCK,
+        BLOCK_M=BLOCK_M,
+    )
+    return out.to(out_dtype) if out_dtype is not torch.float32 else out
+
+
+class _IndexedBiasAdd(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, bias, group_ids, grouped_mm_offs):
+        ctx.bias_dtype = bias.dtype
+        ctx.save_for_backward(grouped_mm_offs)
+        return x + bias[group_ids]
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (offs,) = ctx.saved_tensors
+        grad_out_contig = grad_out.contiguous()
+        bias_grad = _segment_sum_along_rows(grad_out_contig, offs, ctx.bias_dtype)
+        # x is identity-add → grad_x = grad_out; group_ids/offs are integer.
+        return grad_out, bias_grad, None, None
+
+
+def indexed_bias_add(
+    x: torch.Tensor,
+    bias: torch.Tensor,
+    group_ids: torch.Tensor,
+    grouped_mm_offs: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute x + bias[group_ids] with fast segmented-sum backward.
+
+    group_ids must be non-decreasing and grouped_mm_offs the matching
+    per-group cumulative end offsets (i.e. offs[-1] == M).
+    """
+    return _IndexedBiasAdd.apply(x, bias, group_ids, grouped_mm_offs)

--- a/tests/test_indexed_bias_add.py
+++ b/tests/test_indexed_bias_add.py
@@ -1,0 +1,188 @@
+"""
+Correctness tests for the IndexedBiasAdd autograd Function.
+
+The Function computes the same output as ``x + bias[group_ids]``; the
+custom backward swaps PyTorch's bf16 atomic-add bias-grad path for a
+Triton segmented-sum.  Tokens are required to be sorted by group, which
+is always the case post moe_ep_prepare_dispatch.
+
+Each test compares against an fp32 ground truth rather than the bf16
+autograd reference, because the bf16 atomic-add path is itself lossy
+(see test_indexed_bias_add_more_accurate_than_bf16_reference).
+"""
+
+import pytest
+import torch
+
+from pithtrain.operators.indexed_bias_add import indexed_bias_add
+
+
+def _build_sorted_inputs(
+    M: int,
+    H: int,
+    E: int,
+    dtype: torch.dtype,
+    device: str,
+    ks=None,
+):
+    """
+    Build sorted-by-group inputs that match the layout post-dispatch.
+
+    Returns (x, bias, group_ids, offs) all on device.  ``ks``, when given,
+    fixes the per-group token counts (must sum to M).
+    """
+    torch.manual_seed(0)
+    if ks is None:
+        # Random load distribution that sums to M; allow zero-sized groups.
+        weights = torch.rand(E, device=device) + 0.1
+        ks = (weights * (M / weights.sum())).round().to(torch.int64)
+        ks[-1] = M - ks[:-1].sum()
+        assert ks.sum().item() == M
+    else:
+        ks = torch.tensor(ks, device=device, dtype=torch.int64)
+    offs = torch.cumsum(ks, dim=0).to(torch.int32)
+    group_ids = torch.searchsorted(
+        offs.to(torch.int64),
+        torch.arange(M, device=device, dtype=torch.int64),
+        right=True,
+    ).clamp_(max=E - 1)
+    x = torch.randn(M, H, device=device, dtype=dtype)
+    bias = torch.randn(E, H, device=device, dtype=dtype)
+    return x, bias, group_ids, offs
+
+
+def _fp32_ground_truth(x, bias, group_ids, grad_out):
+    """
+    Compute (output, x.grad, bias.grad) under pure fp32 autograd.  The
+    bf16 atomic-add backward used by PyTorch's default index_put_ is
+    itself lossy, so we measure both paths against this fp32 oracle.
+    """
+    xf = x.float().detach().requires_grad_()
+    bf = bias.float().detach().requires_grad_()
+    out = xf + bf[group_ids]
+    out.backward(grad_out.float())
+    return out.detach(), xf.grad, bf.grad
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "M,H,E",
+    [
+        (128, 256, 4),
+        (4096, 2880, 8),
+        (4096, 5760, 8),
+        (1024, 768, 32),
+        (37, 65, 3),
+    ],
+)
+def test_indexed_bias_add_forward_backward(M, H, E, dtype):
+    """
+    Forward output and both gradients agree with autograd within bf16 tol.
+
+    x.grad should be exactly grad_out (identity-add); bias.grad goes
+    through the Triton segmented sum.
+    """
+    device = "cuda"
+    x, bias, group_ids, offs = _build_sorted_inputs(M, H, E, dtype, device)
+    grad_out = torch.randn(M, H, device=device, dtype=dtype)
+
+    # Reference autograd path with the same dtype (the slow bf16/fp16 atomic).
+    x_ref = x.detach().clone().requires_grad_()
+    b_ref = bias.detach().clone().requires_grad_()
+    (x_ref + b_ref[group_ids]).backward(grad_out)
+
+    # Triton-backed Function under test.
+    x_cu = x.detach().clone().requires_grad_()
+    b_cu = bias.detach().clone().requires_grad_()
+    out_cu = indexed_bias_add(x_cu, b_cu, group_ids, offs)
+    out_cu.backward(grad_out)
+
+    # Forward equality is exact; the underlying gather + add is identical.
+    out_ref = x_ref + b_ref[group_ids]
+    torch.testing.assert_close(out_cu, out_ref, atol=0.0, rtol=0.0)
+
+    # x.grad is identity-pass; should match exactly.
+    torch.testing.assert_close(x_cu.grad, x_ref.grad, atol=0.0, rtol=0.0)
+
+    # bias.grad: both paths go through the same atomic noise budget against
+    # the fp32 oracle.  Loosen tolerance to cover bf16 atomic round-off.
+    _, _, bias_grad_gt = _fp32_ground_truth(x, bias, group_ids, grad_out)
+    atol, rtol = (5e-1, 5e-2) if dtype == torch.bfloat16 else (1e-1, 1e-2)
+    torch.testing.assert_close(b_cu.grad.float(), bias_grad_gt, atol=atol, rtol=rtol)
+
+
+def test_indexed_bias_add_more_accurate_than_bf16_reference():
+    """
+    The Triton path uses fp32 accumulation; the autograd default uses
+    bf16 atomic adds.  Against a fp32 ground truth, the Triton path
+    should be at least an order of magnitude more accurate.
+    """
+    device = "cuda"
+    M, H, E = 4096, 5760, 8
+    x, bias, group_ids, offs = _build_sorted_inputs(M, H, E, torch.bfloat16, device)
+    grad_out = torch.randn(M, H, device=device, dtype=torch.bfloat16)
+
+    _, _, bias_grad_gt = _fp32_ground_truth(x, bias, group_ids, grad_out)
+
+    b_ref = bias.detach().clone().requires_grad_()
+    (x.detach().requires_grad_() + b_ref[group_ids]).backward(grad_out)
+    err_ref = (b_ref.grad.float() - bias_grad_gt).abs().max().item()
+
+    b_cu = bias.detach().clone().requires_grad_()
+    indexed_bias_add(x.detach().requires_grad_(), b_cu, group_ids, offs).backward(grad_out)
+    err_cu = (b_cu.grad.float() - bias_grad_gt).abs().max().item()
+
+    assert err_cu < err_ref / 5, (
+        f"Triton path (max-abs err {err_cu:.3e}) should be much closer to fp32 GT "
+        f"than the bf16 atomic-add reference (max-abs err {err_ref:.3e})."
+    )
+
+
+def test_indexed_bias_add_handles_empty_groups():
+    """
+    A group with zero tokens should produce a zero gradient row, not a NaN.
+    This stresses the Triton kernel's loop-bounds: start == end.
+    """
+    device = "cuda"
+    H, E = 256, 6
+    # Group 1 and group 4 are empty; group 0 takes 100 tokens, etc.
+    ks = [100, 0, 50, 200, 0, 150]
+    M = sum(ks)
+    x, bias, group_ids, offs = _build_sorted_inputs(M, H, E, torch.bfloat16, device, ks=ks)
+    grad_out = torch.randn(M, H, device=device, dtype=torch.bfloat16)
+
+    b_cu = bias.detach().clone().requires_grad_()
+    indexed_bias_add(x.detach().requires_grad_(), b_cu, group_ids, offs).backward(grad_out)
+
+    assert torch.isfinite(b_cu.grad).all()
+    # Empty-group rows must be exactly zero.
+    assert (b_cu.grad[1] == 0).all()
+    assert (b_cu.grad[4] == 0).all()
+    # Non-empty rows must be non-trivial.
+    assert b_cu.grad[0].abs().sum() > 0
+    assert b_cu.grad[3].abs().sum() > 0
+
+
+def test_indexed_bias_add_realistic_gpt_oss_shape():
+    """
+    Realistic gpt-oss-20b expert dims: experts_per_rank=8, gate_up_proj
+    width 2 * intermediate_size = 5760, ~512 tokens per expert on average.
+    """
+    device = "cuda"
+    H, E = 5760, 8
+    ks = [512, 768, 320, 256, 1024, 384, 480, 352]
+    M = sum(ks)
+    x, bias, group_ids, offs = _build_sorted_inputs(M, H, E, torch.bfloat16, device, ks=ks)
+    grad_out = torch.randn(M, H, device=device, dtype=torch.bfloat16)
+
+    _, _, bias_grad_gt = _fp32_ground_truth(x, bias, group_ids, grad_out)
+
+    x_cu = x.detach().clone().requires_grad_()
+    b_cu = bias.detach().clone().requires_grad_()
+    out_cu = indexed_bias_add(x_cu, b_cu, group_ids, offs)
+    out_cu.backward(grad_out)
+
+    # Forward is exact.
+    torch.testing.assert_close(out_cu, x + bias[group_ids], atol=0.0, rtol=0.0)
+    # bias.grad within bf16-atomic tolerance of the fp32 GT.
+    torch.testing.assert_close(b_cu.grad.float(), bias_grad_gt, atol=5e-1, rtol=5e-2)


### PR DESCRIPTION
PithTrain GPT-OSS-20B (1n8g B200, PP=2 EP=4, seq=4096, bf16): 137s → 31s. FA-4 replaces flex_attention; new IndexedBiasAdd Function replaces PyTorch's atomic-add bias backward with a Triton segmented-sum kernel.


```
2026-04-28 08:10:49 | INFO | step 00000016/00000025 | step-time 31.113 sec | cross-entropy-loss 5.0374 | load-balance-loss 1.558053 | learning-rate 1.000000e-06 | gradient-norm 255.6650 | tokens-per-second 134,811 | peak-gpu-memory 71.41 GB
2026-04-28 08:11:20 | INFO | step 00000017/00000025 | step-time 31.189 sec | cross-entropy-loss 5.0968 | load-balance-loss 1.568977 | learning-rate 1.000000e-06 | gradient-norm 140.7547 | tokens-per-second 134,481 | peak-gpu-memory 71.43 GB
2026-04-28 08:11:51 | INFO | step 00000018/00000025 | step-time 31.230 sec | cross-entropy-loss 5.0918 | load-balance-loss 1.570418 | learning-rate 1.000000e-06 | gradient-norm 166.2365 | tokens-per-second 134,305 | peak-gpu-memory 71.47 GB
2026-04-28 08:12:23 | INFO | step 00000019/00000025 | step-time 31.166 sec | cross-entropy-loss 5.0898 | load-balance-loss 1.558578 | learning-rate 1.000000e-06 | gradient-norm 216.4712 | tokens-per-second 134,579 | peak-gpu-memory 71.44 GB
2026-04-28 08:12:54 | INFO | step 00000020/00000025 | step-time 31.307 sec | cross-entropy-loss 5.1766 | load-balance-loss 1.565986 | learning-rate 1.000000e-06 | gradient-norm 126.5803 | tokens-per-second 133,973 | peak-gpu-memory 71.48 GB
2026-04-28 08:13:26 | INFO | step 00000021/00000025 | step-time 31.273 sec | cross-entropy-loss 5.1972 | load-balance-loss 1.565822 | learning-rate 1.000000e-06 | gradient-norm 94.3315 | tokens-per-second 134,118 | peak-gpu-memory 71.48 GB
2026-04-28 08:13:57 | INFO | step 00000022/00000025 | step-time 31.177 sec | cross-entropy-loss 5.0843 | load-balance-loss 1.557759 | learning-rate 1.000000e-06 | gradient-norm 74.5268 | tokens-per-second 134,530 | peak-gpu-memory 71.50 GB
2026-04-28 08:14:29 | INFO | step 00000023/00000025 | step-time 31.243 sec | cross-entropy-loss 5.1043 | load-balance-loss 1.557809 | learning-rate 1.000000e-06 | gradient-norm 133.3239 | tokens-per-second 134,249 | peak-gpu-memory 71.55 GB
2026-04-28 08:15:00 | INFO | step 00000024/00000025 | step-time 31.099 sec | cross-entropy-loss 5.0501 | load-balance-loss 1.548457 | learning-rate 1.000000e-06 | gradient-norm 85.4935 | tokens-per-second 134,871 | peak-gpu-memory 71.55 GB
2026-04-28 08:15:31 | INFO | step 00000025/00000025 | step-time 30.995 sec | cross-entropy-loss 5.0656 | load-balance-loss 1.537359 | learning-rate 1.000000e-06 | gradient-norm 79.4577 | tokens-per-second 135,323 | peak-gpu-memory 71.55 GB
```