### PR TITLE
Refactor SLURM integration for torchrun

### DIFF
--- a/.claude/skills/capture-nsys-profile/scripts/launch_capture.sh
+++ b/.claude/skills/capture-nsys-profile/scripts/launch_capture.sh
@@ -8,27 +8,19 @@ export PYTHONUNBUFFERED=1
 OUTDIR=workspace/capture-nsys-profile; mkdir -p $OUTDIR
 SCRIPT=.claude/skills/capture-nsys-profile/scripts/capture.py
 
-SLURM_NNODES=${SLURM_NNODES:-1}
-SLURM_NODEID=${SLURM_NODEID:-0}
-SLURM_STEP_NODELIST=${SLURM_STEP_NODELIST:-$(hostname)}
-RDZV_HOST=$(command -v scontrol &>/dev/null && scontrol show hostnames $SLURM_STEP_NODELIST | head -n 1 || echo localhost)
-
 NSYS_ARGS=()
 NSYS_ARGS+=(profile)
 NSYS_ARGS+=(--stats=false)
 NSYS_ARGS+=(--trace=cuda,nvtx)
 NSYS_ARGS+=(--force-overwrite=true)
-NSYS_ARGS+=(--output=$OUTDIR/pithtrain_node${SLURM_NODEID})
+NSYS_ARGS+=(--output=$OUTDIR/pithtrain_node${SLURM_NODEID:-0})
 NSYS_ARGS+=(--cuda-graph-trace=node)
 NSYS_ARGS+=(--capture-range=cudaProfilerApi)
 NSYS_ARGS+=(--capture-range-end=stop-shutdown)
 NSYS_ARGS+=(--delay=0)
 
 TORCHRUN_ARGS=()
-TORCHRUN_ARGS+=(--nnodes=$SLURM_NNODES)
-TORCHRUN_ARGS+=(--node-rank=$SLURM_NODEID)
-TORCHRUN_ARGS+=(--nproc-per-node=gpu)
-TORCHRUN_ARGS+=(--rdzv-backend=c10d)
-TORCHRUN_ARGS+=(--rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=${SLURM_LAUNCH_NODE_IPADDR:-localhost}:15213)
 
 nsys ${NSYS_ARGS[@]} torchrun ${TORCHRUN_ARGS[@]} $SCRIPT $@

--- a/.claude/skills/validate-correctness/scripts/launch_validate.sh
+++ b/.claude/skills/validate-correctness/scripts/launch_validate.sh
@@ -7,16 +7,8 @@ export PYTHONUNBUFFERED=1
 
 SCRIPT=.claude/skills/validate-correctness/scripts/validate.py
 
-SLURM_NNODES=${SLURM_NNODES:-1}
-SLURM_NODEID=${SLURM_NODEID:-0}
-SLURM_STEP_NODELIST=${SLURM_STEP_NODELIST:-$(hostname)}
-RDZV_HOST=$(command -v scontrol &>/dev/null && scontrol show hostnames $SLURM_STEP_NODELIST | head -n 1 || echo localhost)
-
 TORCHRUN_ARGS=()
-TORCHRUN_ARGS+=(--nnodes=$SLURM_NNODES)
-TORCHRUN_ARGS+=(--node-rank=$SLURM_NODEID)
-TORCHRUN_ARGS+=(--nproc-per-node=gpu)
-TORCHRUN_ARGS+=(--rdzv-backend=c10d)
-TORCHRUN_ARGS+=(--rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=${SLURM_LAUNCH_NODE_IPADDR:-localhost}:15213)
 
 torchrun ${TORCHRUN_ARGS[@]} $SCRIPT $@

--- a/examples/pretrain_language_model/launch.sh
+++ b/examples/pretrain_language_model/launch.sh
@@ -18,16 +18,9 @@ if [ $# -ne 1 ]; then
 fi
 
 # Setup distributed.
-SLURM_NNODES=${SLURM_NNODES:-1}
-SLURM_NODEID=${SLURM_NODEID:-0}
-SLURM_STEP_GPUS=${SLURM_STEP_GPUS:-${CUDA_VISIBLE_DEVICES:-$(nvidia-smi --query-gpu=index --format=csv,noheader | paste -sd,)}}
-SLURM_STEP_NODELIST=${SLURM_STEP_NODELIST:-$(hostname)}
-
 LAUNCH_ARGS=()
-LAUNCH_ARGS+=(--nnodes=$SLURM_NNODES --node-rank=$SLURM_NODEID)
-LAUNCH_ARGS+=(--nproc-per-node=$(echo "$SLURM_STEP_GPUS" | tr ',' '\n' | wc -l))
-LAUNCH_ARGS+=(--rdzv-backend=c10d)
-LAUNCH_ARGS+=(--rdzv-endpoint=$(command -v scontrol &>/dev/null && scontrol show hostnames $SLURM_STEP_NODELIST | head -n 1 || echo localhost):15213)
+LAUNCH_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
+LAUNCH_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=${SLURM_LAUNCH_NODE_IPADDR:-localhost}:15213)
 
 # Launch the training.
 SCRIPT=examples/pretrain_language_model/$1/script.py


### PR DESCRIPTION
1. Use `--nproc-per-node=gpu` to automatically detect the number of GPUs on each node ; we used to parse from the `SLURM_STEP_GPUS` with a fallback to  `nvidia-smi`, which is cumbersome.
2. Use the dedicated environment `SLURM_LAUNCH_NODE_IPADDR` that provides the IP address of the head node for `--rdzv-endpoint` ; we used to parse from `SLURM_STEP_NODELIST` and extract the first one.

---

Multi-node training still launch properly after this cleanup.

```
(pith-train) haok@orchard-flame-11:~/pith-train$ srun -W 0 examples/pretrain_language_model/launch.sh qwen3-30b-a3b
[rank0] layer_partition: 48 layers / 4 stages -> [12, 12, 12, 12]
[rank0] layer_partition: 48 layers / 4 stages -> [12, 12, 12, 12]
2026-05-30 17:34:05 | INFO | launch(cfg=PretrainLanguageModelCfg(distributed=DistributedCfg(pipeline_parallel_size=2, context_parallel_size=1, expert_parallel_size=8, timeout=datetime.timedelta(seconds=900), sharding_strategy='fsdp'), training=TrainingCfg(dataset=PosixPath('workspace/datasets/dclm-baseline/toktxt/qwen3'), sequence_length=2048, seed=1234, min_lr=1e-05, max_lr=0.0003, warmup_steps=128, max_steps=4096, micro_batch_size=1, global_batch_size=1024, optimizer='Adam', scheduler='CosineAnnealing', model=PosixPath('examples/pretrain_language_model/qwen3-30b-a3b/config.json'), save_interval=256, save_location=PosixPath('workspace/checkpoints/qwen3-30b-a3b'), moe_load_balance_coef=0.001, moe_load_balance_type='global-batch', fp8_training='disabled', init_std=0.02, nsys_start=None, nsys_stop=None, memory_profile_start=None, memory_profile_stop=None, memory_profile_output=PosixPath('/home/haok/pith-train')), logging=LoggingCfg(wandb=LoggingWandbCfg(entity='', project='', name='qwen3-30b-a3b', group=None))))
2026-05-30 17:34:05 | INFO | No checkpoint found; training from scratch.
2026-05-30 17:36:25 | INFO | step 00000001/00004096 | step-time 140.215 sec | cross-entropy-loss 12.3463 | load-balance-loss 1.423156 | learning-rate 1.226563e-05 | gradient-norm 32.5911 | tokens-per-second 14,957 | peak-gpu-memory 41.59 GB
wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from /home/haok/.netrc.
wandb: Currently logged in as: haok (Pith-Train) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.27.0
wandb: Run data is saved locally in /tmp/wandb/wandb/run-20260530_173627-ltk8x119
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run qwen3-30b-a3b
wandb: ⭐️ View project at https://wandb.ai/Pith-Train/uncategorized
wandb: 🚀 View run at https://wandb.ai/Pith-Train/uncategorized/runs/ltk8x119
2026-05-30 17:36:58 | INFO | step 00000002/00004096 | step-time 31.936 sec | cross-entropy-loss 10.9425 | load-balance-loss 2.491849 | learning-rate 1.453125e-05 | gradient-norm 36.2835 | tokens-per-second 65,667 | peak-gpu-memory 55.91 GB
2026-05-30 17:37:26 | INFO | step 00000003/00004096 | step-time 28.275 sec | cross-entropy-loss 10.9974 | load-balance-loss 3.525070 | learning-rate 1.679688e-05 | gradient-norm 90.9986 | tokens-per-second 74,170 | peak-gpu-memory 56.70 GB
```