### PR TITLE
MLA pass-latent CP support FP8 (remove silent bf16 fallback)

### DIFF
--- a/pithtrain/layers/deepgemm_fp8_linear.py
+++ b/pithtrain/layers/deepgemm_fp8_linear.py
@@ -41,6 +41,66 @@ def _m_grouped_fp8_gemm_nt(a, b, d, grouped_mm_offs, M, group_indices=None):
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(a, b, d, group_indices)
 
 
+def _fp8_gemm_nt(
+    a_fp8: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_fp8: torch.Tensor,
+    b_scale: torch.Tensor,
+    m: int,
+    n: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """``out[m, n] = a @ b.T`` via the DeepGEMM fp8 NT GEMM. The single place that owns the
+    allocate-then-``fp8_fp4_gemm_nt`` convention shared by the FP8 linear layer and the MLA
+    pass-latent ring decompress."""
+    out = torch.empty((m, n), device=device, dtype=dtype)
+    deep_gemm.fp8_fp4_gemm_nt((a_fp8, a_scale), (b_fp8, b_scale), out)
+    return out
+
+
+def fp8_act_weight_gemm(
+    input_2d: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    scale_weight: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """FP8 forward GEMM ``y = x @ W.T``: rowwise-quantize the activation, run the NT GEMM, and
+    return ``(output, input_t_fp8, scale_input_t)`` -- the transposed activation is handed back
+    so a later wgrad can reuse it. Shared by ``_fp8_linear_fwd`` and the MLA ring so the recipe
+    has one source of truth."""
+    m, n = input_2d.shape[0], weight_fp8.shape[0]
+    input_fp8, scale_input, input_t_fp8, scale_input_t = (
+        fused_rowwise_blockwise_transpose_cast_to_fp8(input_2d)
+    )
+    output = _fp8_gemm_nt(
+        input_fp8, scale_input, weight_fp8, scale_weight, m, n, input_2d.device, input_2d.dtype
+    )
+    return output, input_t_fp8, scale_input_t
+
+
+def fp8_dgrad_wgrad(
+    grad_2d: torch.Tensor,
+    weight_t_fp8: torch.Tensor,
+    scale_weight_t: torch.Tensor,
+    input_t_fp8: torch.Tensor,
+    scale_input_t: torch.Tensor,
+    k: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """FP8 backward GEMMs: ``grad_input = grad @ W`` (via the transposed weight) and
+    ``weight_grad = grad.T @ x`` (via the transposed activation), both returned in ``grad_2d``'s
+    dtype. Shared by ``_fp8_linear_bwd`` and the MLA ring so dgrad/wgrad have one source of
+    truth; the caller supplies ``input_t_fp8`` (saved from the forward, or recomputed)."""
+    m, n = grad_2d.shape
+    grad_fp8, scale_grad, grad_t_fp8, scale_grad_t = fused_rowwise_transpose_cast_to_fp8(grad_2d)
+    grad_input = _fp8_gemm_nt(
+        grad_fp8, scale_grad, weight_t_fp8, scale_weight_t, m, k, grad_2d.device, grad_2d.dtype
+    )
+    weight_grad = _fp8_gemm_nt(
+        grad_t_fp8, scale_grad_t, input_t_fp8, scale_input_t, n, k, grad_2d.device, grad_2d.dtype
+    )
+    return grad_input, weight_grad
+
+
 @torch.library.custom_op("pithtrain::fp8_linear_fwd", mutates_args=())
 def _fp8_linear_fwd(
     input_2d: torch.Tensor,
@@ -62,13 +122,7 @@ def _fp8_linear_fwd(
     scale_input_t : torch.Tensor
         Block scales for input_t_fp8, saved for wgrad.
     """
-    (M, _), N = input_2d.shape, weight.shape[0]
-    input_fp8, scale_input, input_t_fp8, scale_input_t = (
-        fused_rowwise_blockwise_transpose_cast_to_fp8(input_2d)
-    )
-    output = torch.empty((M, N), device=input_2d.device, dtype=input_2d.dtype)
-    deep_gemm.fp8_fp4_gemm_nt((input_fp8, scale_input), (weight_fp8, scale_weight), output)
-    return output, input_t_fp8, scale_input_t
+    return fp8_act_weight_gemm(input_2d, weight_fp8, scale_weight)
 
 
 @_fp8_linear_fwd.register_fake
@@ -100,15 +154,9 @@ def _fp8_linear_bwd(
     weight_grad : torch.Tensor
         (N, K) weight gradient.
     """
-    M, N = grad_output_2d.shape
-    grad_fp8, scale_grad, grad_t_fp8, scale_grad_t = fused_rowwise_transpose_cast_to_fp8(
-        grad_output_2d
+    return fp8_dgrad_wgrad(
+        grad_output_2d, weight_t_fp8, scale_weight_t, input_t_fp8, scale_input_t, K
     )
-    grad_input = torch.empty((M, K), device=grad_output_2d.device, dtype=grad_output_2d.dtype)
-    deep_gemm.fp8_fp4_gemm_nt((grad_fp8, scale_grad), (weight_t_fp8, scale_weight_t), grad_input)
-    weight_grad = torch.empty((N, K), device=grad_output_2d.device, dtype=grad_output_2d.dtype)
-    deep_gemm.fp8_fp4_gemm_nt((grad_t_fp8, scale_grad_t), (input_t_fp8, scale_input_t), weight_grad)
-    return grad_input, weight_grad
 
 
 @_fp8_linear_bwd.register_fake

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -375,6 +375,9 @@ class DeepseekV2LiteAttention(nn.Module):
 
         self.o_proj = LinearCls(self.num_heads * self.v_head_dim, self.hidden_size, bias=False)
         self.softmax_scale = self.q_head_dim ** (-0.5)
+        # When fp8 training is on, kv_b_proj is an FP8Linear; the pass-latent ring decompresses
+        # the rotated latent via the FP8 deep_gemm path instead of a silent bf16 F.linear.
+        self._fp8 = ModelImplMode.fp8_training == "deep-gemm"
 
     def forward(
         self,
@@ -401,6 +404,7 @@ class DeepseekV2LiteAttention(nn.Module):
             # k_pe) around the ring and decompress on each rank via kv_b, instead of
             # decompressing to full per-head K/V before rotating. ~9x less ring traffic
             # for DeepSeek-V2-Lite.
+            kv_b_quant = self.kv_b_proj._get_quantized_weight() if self._fp8 else None
             attn_output = mla_ring_attention_func(
                 q_nope,
                 q_pe,
@@ -411,6 +415,7 @@ class DeepseekV2LiteAttention(nn.Module):
                 qk_nope_head_dim=self.qk_nope_head_dim,
                 v_head_dim=self.v_head_dim,
                 cp_group=self.cp_group,
+                kv_b_quant=kv_b_quant,
             )
         else:
             kv = self.kv_b_proj(normed_kv).view(

--- a/pithtrain/operators/ring_attention.py
+++ b/pithtrain/operators/ring_attention.py
@@ -50,7 +50,6 @@ Every step costs the same: one causal pass on length 2*block, or one non-causal 
 
 from typing import List, Optional, Tuple
 
-import deep_gemm
 import torch
 import torch.nn.functional as F
 from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
@@ -66,11 +65,12 @@ from torch.distributed import (
     isend,
 )
 
-# FP8 (deep-gemm) primitives for the in-ring kv_b decompression; reached only when the caller
-# passes a quantized kv_b weight (i.e. fp8_training="deep-gemm").
+# FP8 (deep-gemm) shared GEMM recipe + the activation quantizer for the in-ring kv_b
+# decompression; reached only when the caller passes a quantized kv_b weight
+# (i.e. fp8_training="deep-gemm").
+from pithtrain.layers.deepgemm_fp8_linear import fp8_act_weight_gemm, fp8_dgrad_wgrad
 from pithtrain.operators.deepgemm_fp8_quantize import (
     fused_rowwise_blockwise_transpose_cast_to_fp8,
-    fused_rowwise_transpose_cast_to_fp8,
 )
 
 
@@ -378,12 +378,9 @@ def _mla_decompress(
     is pre-quantized once per micro-batch by the caller (``weight_fp8``/``scale_weight``).
     """
     b, n, _ = normed_kv.shape
-    out_features = kv_b_weight.shape[0]
     if use_fp8:
         x2d = normed_kv.reshape(b * n, normed_kv.shape[-1])
-        x_fp8, x_scale, _, _ = fused_rowwise_blockwise_transpose_cast_to_fp8(x2d)
-        kv2d = torch.empty((b * n, out_features), device=normed_kv.device, dtype=normed_kv.dtype)
-        deep_gemm.fp8_fp4_gemm_nt((x_fp8, x_scale), (weight_fp8, scale_weight), kv2d)
+        kv2d, _, _ = fp8_act_weight_gemm(x2d, weight_fp8, scale_weight)
         kv = kv2d.view(b, n, num_heads, qk_nope_head_dim + v_head_dim)
     else:
         kv = F.linear(normed_kv, kv_b_weight).view(b, n, num_heads, qk_nope_head_dim + v_head_dim)
@@ -572,31 +569,21 @@ def mla_zigzag_backward(
         dk_nope, dk_pe = torch.split(dkey_step, [qk_nope_head_dim, rope_dim], dim=-1)
         n = dk_nope.shape[1]
         if use_fp8:
-            # FP8 dgrad/wgrad, mirroring _fp8_linear_bwd. dy = [dk_nope | dvalue] (M, out_features).
+            # FP8 dgrad/wgrad via the shared recipe. dy = [dk_nope | dvalue] (M, out_features).
+            # The wgrad needs this hop's latent block transposed; we re-quantize it here rather
+            # than stash it from the forward (recompute is the deliberate memory/compute trade).
             dy2d = (
                 torch.cat([dk_nope, dvalue_step], dim=-1)
                 .reshape(b * n, out_features)
                 .to(normed_kv.dtype)
             )
-            grad_fp8, scale_grad, grad_t_fp8, scale_grad_t = fused_rowwise_transpose_cast_to_fp8(
-                dy2d
-            )
-            # dgrad: d_normed_kv = dy @ W, via the pre-transposed fp8 weight.
-            d_nkv_2d = torch.empty(
-                (b * n, lora_rank), device=normed_kv.device, dtype=normed_kv.dtype
-            )
-            deep_gemm.fp8_fp4_gemm_nt(
-                (grad_fp8, scale_grad), (weight_t_fp8, scale_weight_t), d_nkv_2d
-            )
-            d_nkv_blk = d_nkv_2d.view(b, n, lora_rank).to(torch.float32)
-            # wgrad: dW += dy^T @ x, re-quantizing this hop's latent block (transposed).
             _, _, x_t_fp8, scale_x_t = fused_rowwise_blockwise_transpose_cast_to_fp8(
                 nkv_blk.reshape(b * n, lora_rank)
             )
-            dW_blk = torch.empty(
-                (out_features, lora_rank), device=normed_kv.device, dtype=normed_kv.dtype
+            d_nkv_2d, dW_blk = fp8_dgrad_wgrad(
+                dy2d, weight_t_fp8, scale_weight_t, x_t_fp8, scale_x_t, lora_rank
             )
-            deep_gemm.fp8_fp4_gemm_nt((grad_t_fp8, scale_grad_t), (x_t_fp8, scale_x_t), dW_blk)
+            d_nkv_blk = d_nkv_2d.view(b, n, lora_rank).to(torch.float32)
             dW += dW_blk.to(torch.float32)
         else:
             d_kv = (

--- a/pithtrain/operators/ring_attention.py
+++ b/pithtrain/operators/ring_attention.py
@@ -65,6 +65,19 @@ from torch.distributed import (
     isend,
 )
 
+# FP8 (deep-gemm) primitives for the in-ring kv_b decompression. Guarded so the BF16 path
+# (and environments without deep_gemm) import ring_attention cleanly; only reached when the
+# caller passes a quantized kv_b weight (i.e. fp8_training="deep-gemm").
+try:
+    import deep_gemm
+
+    from pithtrain.operators.deepgemm_fp8_quantize import (
+        fused_rowwise_blockwise_transpose_cast_to_fp8,
+        fused_rowwise_transpose_cast_to_fp8,
+    )
+except ImportError:
+    deep_gemm = None
+
 
 def post_ring_kv(
     k: torch.Tensor,
@@ -358,11 +371,27 @@ def _mla_decompress(
     num_heads: int,
     qk_nope_head_dim: int,
     v_head_dim: int,
+    *,
+    use_fp8: bool = False,
+    weight_fp8: Optional[torch.Tensor] = None,
+    scale_weight: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Decompress a latent block into per-head (k_nope, value) via kv_b: y = x @ Wt."""
+    """Decompress a latent block into per-head (k_nope, value) via kv_b: y = x @ Wt.
+
+    When ``use_fp8`` the matmul uses the DeepGEMM FP8 path (mirroring FP8Linear): the latent
+    block is rowwise-quantized to FP8 here (it differs every ring hop), and the kv_b weight
+    is pre-quantized once per micro-batch by the caller (``weight_fp8``/``scale_weight``).
+    """
     b, n, _ = normed_kv.shape
-    kv = F.linear(normed_kv, kv_b_weight)
-    kv = kv.view(b, n, num_heads, qk_nope_head_dim + v_head_dim)
+    out_features = kv_b_weight.shape[0]
+    if use_fp8:
+        x2d = normed_kv.reshape(b * n, normed_kv.shape[-1])
+        x_fp8, x_scale, _, _ = fused_rowwise_blockwise_transpose_cast_to_fp8(x2d)
+        kv2d = torch.empty((b * n, out_features), device=normed_kv.device, dtype=normed_kv.dtype)
+        deep_gemm.fp8_fp4_gemm_nt((x_fp8, x_scale), (weight_fp8, scale_weight), kv2d)
+        kv = kv2d.view(b, n, num_heads, qk_nope_head_dim + v_head_dim)
+    else:
+        kv = F.linear(normed_kv, kv_b_weight).view(b, n, num_heads, qk_nope_head_dim + v_head_dim)
     k_nope, value = torch.split(kv, [qk_nope_head_dim, v_head_dim], dim=-1)
     # k_nope is consumed only by `torch.cat([k_nope, k_pe.expand(...)], dim=-1)`, which
     # materialises a fresh contiguous output regardless of input strides -- the .contiguous()
@@ -381,12 +410,17 @@ def mla_zigzag_forward(
     qk_nope_head_dim: int,
     v_head_dim: int,
     cp_group: ProcessGroup,
+    *,
+    use_fp8: bool = False,
+    weight_fp8: Optional[torch.Tensor] = None,
+    scale_weight: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     cp_rank, cp_size = get_rank(cp_group), get_world_size(cp_group)
     dst = get_global_rank(cp_group, (cp_rank + 1) % cp_size)
     src = get_global_rank(cp_group, (cp_rank - 1) % cp_size)
     num_heads = q_nope.shape[2]
     block = q_nope.shape[1] // 2
+    _fp8_kw = dict(use_fp8=use_fp8, weight_fp8=weight_fp8, scale_weight=scale_weight)
 
     q = torch.cat([q_nope, q_pe], dim=-1)
     # q_back is a strided view (kept non-contiguous in forward to match the standard zigzag
@@ -405,7 +439,7 @@ def mla_zigzag_forward(
             next_kv, next_pe, kv_work = post_ring_kv(normed_kv, k_pe, cp_group, dst, src)
         if step == 0:
             k_nope, value = _mla_decompress(
-                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
             partial_out, partial_lse = _flash_attn_fwd(
@@ -414,7 +448,12 @@ def mla_zigzag_forward(
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
         elif step <= cp_rank:
             k_nope, value = _mla_decompress(
-                normed_kv[:, :block], kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                normed_kv[:, :block],
+                kv_b_weight,
+                num_heads,
+                qk_nope_head_dim,
+                v_head_dim,
+                **_fp8_kw,
             )
             key = torch.cat([k_nope, k_pe[:, :block].expand(-1, -1, num_heads, -1)], dim=-1)
             partial_out, partial_lse = _flash_attn_fwd(
@@ -423,7 +462,7 @@ def mla_zigzag_forward(
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
         else:
             k_nope, value = _mla_decompress(
-                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
             partial_out, partial_lse = _flash_attn_fwd(
@@ -452,6 +491,12 @@ def mla_zigzag_backward(
     qk_nope_head_dim: int,
     v_head_dim: int,
     cp_group: ProcessGroup,
+    *,
+    use_fp8: bool = False,
+    weight_fp8: Optional[torch.Tensor] = None,
+    scale_weight: Optional[torch.Tensor] = None,
+    weight_t_fp8: Optional[torch.Tensor] = None,
+    scale_weight_t: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     cp_rank, cp_size = get_rank(cp_group), get_world_size(cp_group)
     dst = get_global_rank(cp_group, (cp_rank + 1) % cp_size)
@@ -462,7 +507,8 @@ def mla_zigzag_backward(
     rope_dim = k_pe.shape[-1]
     lora_rank = normed_kv.shape[-1]
     out_features = kv_b_weight.shape[0]
-    weight_f = kv_b_weight.to(torch.float32)
+    weight_f = None if use_fp8 else kv_b_weight.to(torch.float32)
+    _fp8_kw = dict(use_fp8=use_fp8, weight_fp8=weight_fp8, scale_weight=scale_weight)
 
     q = torch.cat([q_nope, q_pe], dim=-1)
     dout = dout.contiguous()
@@ -472,7 +518,7 @@ def mla_zigzag_backward(
     lse_back = lse[:, :, block:].contiguous()
 
     dq: Optional[torch.Tensor] = None
-    dW = torch.zeros_like(weight_f)
+    dW = torch.zeros((out_features, lora_rank), device=kv_b_weight.device, dtype=torch.float32)
     d_nkv: Optional[torch.Tensor] = None
     d_kpe: Optional[torch.Tensor] = None
     next_kv: Optional[torch.Tensor] = None
@@ -492,7 +538,7 @@ def mla_zigzag_backward(
         if step == 0:
             nkv_blk = normed_kv
             k_nope, value = _mla_decompress(
-                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
             dq_step, dkey_step, dvalue_step = _flash_attn_bwd(
@@ -502,7 +548,7 @@ def mla_zigzag_backward(
         elif step <= cp_rank:
             nkv_blk = normed_kv[:, :block]
             k_nope, value = _mla_decompress(
-                nkv_blk, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                nkv_blk, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe[:, :block].expand(-1, -1, num_heads, -1)], dim=-1)
             dq_step, dkey_step, dvalue_step = _flash_attn_bwd(
@@ -512,7 +558,7 @@ def mla_zigzag_backward(
         else:
             nkv_blk = normed_kv
             k_nope, value = _mla_decompress(
-                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim
+                normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
             dq_step, dkey_step, dvalue_step = _flash_attn_bwd(
@@ -530,11 +576,41 @@ def mla_zigzag_backward(
         # Backprop the decompression: (dk_nope, dvalue) -> d(normed_kv) + kv_b weight grad.
         dk_nope, dk_pe = torch.split(dkey_step, [qk_nope_head_dim, rope_dim], dim=-1)
         n = dk_nope.shape[1]
-        d_kv = (
-            torch.cat([dk_nope, dvalue_step], dim=-1).reshape(b * n, out_features).to(torch.float32)
-        )
-        d_nkv_blk = (d_kv @ weight_f).view(b, n, lora_rank)
-        dW += d_kv.t() @ nkv_blk.reshape(b * n, lora_rank).to(torch.float32)
+        if use_fp8:
+            # FP8 dgrad/wgrad, mirroring _fp8_linear_bwd. dy = [dk_nope | dvalue] (M, out_features).
+            dy2d = (
+                torch.cat([dk_nope, dvalue_step], dim=-1)
+                .reshape(b * n, out_features)
+                .to(normed_kv.dtype)
+            )
+            grad_fp8, scale_grad, grad_t_fp8, scale_grad_t = fused_rowwise_transpose_cast_to_fp8(
+                dy2d
+            )
+            # dgrad: d_normed_kv = dy @ W, via the pre-transposed fp8 weight.
+            d_nkv_2d = torch.empty(
+                (b * n, lora_rank), device=normed_kv.device, dtype=normed_kv.dtype
+            )
+            deep_gemm.fp8_fp4_gemm_nt(
+                (grad_fp8, scale_grad), (weight_t_fp8, scale_weight_t), d_nkv_2d
+            )
+            d_nkv_blk = d_nkv_2d.view(b, n, lora_rank).to(torch.float32)
+            # wgrad: dW += dy^T @ x, re-quantizing this hop's latent block (transposed).
+            _, _, x_t_fp8, scale_x_t = fused_rowwise_blockwise_transpose_cast_to_fp8(
+                nkv_blk.reshape(b * n, lora_rank)
+            )
+            dW_blk = torch.empty(
+                (out_features, lora_rank), device=normed_kv.device, dtype=normed_kv.dtype
+            )
+            deep_gemm.fp8_fp4_gemm_nt((grad_t_fp8, scale_grad_t), (x_t_fp8, scale_x_t), dW_blk)
+            dW += dW_blk.to(torch.float32)
+        else:
+            d_kv = (
+                torch.cat([dk_nope, dvalue_step], dim=-1)
+                .reshape(b * n, out_features)
+                .to(torch.float32)
+            )
+            d_nkv_blk = (d_kv @ weight_f).view(b, n, lora_rank)
+            dW += d_kv.t() @ nkv_blk.reshape(b * n, lora_rank).to(torch.float32)
         d_kpe_blk = dk_pe.sum(dim=2, keepdim=True).to(torch.float32).contiguous()
 
         # dq accumulates locally (queries never leave their home rank).
@@ -598,11 +674,19 @@ class MLAZigzagRingAttention(torch.autograd.Function):
         qk_nope_head_dim,
         v_head_dim,
         cp_group,
+        kv_b_quant=None,
     ):
         if not (normed_kv.is_contiguous() and k_pe.is_contiguous()):
             raise ValueError("MLA ring attention requires contiguous normed_kv and k_pe")
         if q_nope.shape[1] % 2:
             raise ValueError(f"zigzag layout needs even local seq len, got {q_nope.shape[1]}")
+        # kv_b_quant is the FP8-quantized kv_b weight tuple (weight_fp8, scale_weight,
+        # weight_t_fp8, scale_weight_t), pre-quantized once per micro-batch by the caller when
+        # fp8_training="deep-gemm"; None -> bf16 F.linear decompress.
+        use_fp8 = kv_b_quant is not None
+        weight_fp8, scale_weight, weight_t_fp8, scale_weight_t = (
+            kv_b_quant if use_fp8 else (None, None, None, None)
+        )
         out, lse = mla_zigzag_forward(
             q_nope,
             q_pe,
@@ -613,12 +697,20 @@ class MLAZigzagRingAttention(torch.autograd.Function):
             qk_nope_head_dim,
             v_head_dim,
             cp_group,
+            use_fp8=use_fp8,
+            weight_fp8=weight_fp8,
+            scale_weight=scale_weight,
         )
         ctx.save_for_backward(q_nope, q_pe, normed_kv, k_pe, kv_b_weight, out, lse)
         ctx.sm_scale = sm_scale
         ctx.qk_nope_head_dim = qk_nope_head_dim
         ctx.v_head_dim = v_head_dim
         ctx.cp_group = cp_group
+        ctx.use_fp8 = use_fp8
+        ctx.weight_fp8 = weight_fp8
+        ctx.scale_weight = scale_weight
+        ctx.weight_t_fp8 = weight_t_fp8
+        ctx.scale_weight_t = scale_weight_t
         return out
 
     @staticmethod
@@ -637,8 +729,13 @@ class MLAZigzagRingAttention(torch.autograd.Function):
             ctx.qk_nope_head_dim,
             ctx.v_head_dim,
             ctx.cp_group,
+            use_fp8=ctx.use_fp8,
+            weight_fp8=ctx.weight_fp8,
+            scale_weight=ctx.scale_weight,
+            weight_t_fp8=ctx.weight_t_fp8,
+            scale_weight_t=ctx.scale_weight_t,
         )
-        return dq_nope, dq_pe, d_normed_kv, d_k_pe, dW, None, None, None, None
+        return dq_nope, dq_pe, d_normed_kv, d_k_pe, dW, None, None, None, None, None
 
 
 def mla_ring_attention_func(
@@ -651,6 +748,7 @@ def mla_ring_attention_func(
     qk_nope_head_dim: int,
     v_head_dim: int,
     cp_group: ProcessGroup,
+    kv_b_quant: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]] = None,
 ) -> torch.Tensor:
     """
     Causal zigzag ring attention for MLA, rotating the compressed latent.
@@ -676,6 +774,12 @@ def mla_ring_attention_func(
         Head dims used to split the decompressed kv into (k_nope, value).
     cp_group : torch.distributed.ProcessGroup
         Context-parallel process group (>= 2 ranks; cp_size == 1 is handled upstream).
+    kv_b_quant : optional tuple
+        (weight_fp8, scale_weight, weight_t_fp8, scale_weight_t) -- the kv_b weight
+        pre-quantized once per micro-batch via FP8Linear._get_quantized_weight(). When given,
+        the in-ring decompression uses the FP8 DeepGEMM path (matmul + dgrad/wgrad) instead of
+        a bf16 F.linear. None -> bf16 path. ``kv_b_weight`` (the bf16 master) is still passed
+        so its gradient (dW) routes to kv_b_proj.weight for FSDP.
 
     Returns
     -------
@@ -683,5 +787,14 @@ def mla_ring_attention_func(
         Attention output [batch, S_local, num_heads, v_head_dim] in q dtype, zigzag layout.
     """
     return MLAZigzagRingAttention.apply(
-        q_nope, q_pe, normed_kv, k_pe, kv_b_weight, sm_scale, qk_nope_head_dim, v_head_dim, cp_group
+        q_nope,
+        q_pe,
+        normed_kv,
+        k_pe,
+        kv_b_weight,
+        sm_scale,
+        qk_nope_head_dim,
+        v_head_dim,
+        cp_group,
+        kv_b_quant,
     )

--- a/pithtrain/operators/ring_attention.py
+++ b/pithtrain/operators/ring_attention.py
@@ -50,6 +50,7 @@ Every step costs the same: one causal pass on length 2*block, or one non-causal 
 
 from typing import List, Optional, Tuple
 
+import deep_gemm
 import torch
 import torch.nn.functional as F
 from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
@@ -65,18 +66,12 @@ from torch.distributed import (
     isend,
 )
 
-# FP8 (deep-gemm) primitives for the in-ring kv_b decompression. Guarded so the BF16 path
-# (and environments without deep_gemm) import ring_attention cleanly; only reached when the
-# caller passes a quantized kv_b weight (i.e. fp8_training="deep-gemm").
-try:
-    import deep_gemm
-
-    from pithtrain.operators.deepgemm_fp8_quantize import (
-        fused_rowwise_blockwise_transpose_cast_to_fp8,
-        fused_rowwise_transpose_cast_to_fp8,
-    )
-except ImportError:
-    deep_gemm = None
+# FP8 (deep-gemm) primitives for the in-ring kv_b decompression; reached only when the caller
+# passes a quantized kv_b weight (i.e. fp8_training="deep-gemm").
+from pithtrain.operators.deepgemm_fp8_quantize import (
+    fused_rowwise_blockwise_transpose_cast_to_fp8,
+    fused_rowwise_transpose_cast_to_fp8,
+)
 
 
 def post_ring_kv(

--- a/tests/operators/test_ring_attention.py
+++ b/tests/operators/test_ring_attention.py
@@ -247,18 +247,11 @@ def test_mla_ring_attention_vs_dense(cp_size: int, req: MLARequest) -> None:
 # FP8 in-ring kv_b decompression (pass-latent CP with fp8_training="deep-gemm").
 # ---------------------------------------------------------------------------
 
-try:
-    import deep_gemm  # noqa: F401
-
-    _HAS_DEEP_GEMM = True
-except ImportError:
-    _HAS_DEEP_GEMM = False
-
+# deep_gemm is a required dependency (GPU-only project), so no import guard; gate only on the
+# hardware the FP8 GEMM actually needs.
 requires_fp8 = pytest.mark.skipif(
-    not (
-        _HAS_DEEP_GEMM and torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
-    ),
-    reason="FP8 kv_b path requires deep_gemm + Hopper (SM90)+",
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9),
+    reason="FP8 kv_b path requires Hopper (SM90)+",
 )
 
 

--- a/tests/operators/test_ring_attention.py
+++ b/tests/operators/test_ring_attention.py
@@ -241,3 +241,140 @@ def test_mla_ring_attention_vs_dense(cp_size: int, req: MLARequest) -> None:
     cfg = DistributedCfg()
     cfg.context_parallel_size = cp_size
     launch(cfg, verify_mla, req)
+
+
+# ---------------------------------------------------------------------------
+# FP8 in-ring kv_b decompression (pass-latent CP with fp8_training="deep-gemm").
+# ---------------------------------------------------------------------------
+
+try:
+    import deep_gemm  # noqa: F401
+
+    _HAS_DEEP_GEMM = True
+except ImportError:
+    _HAS_DEEP_GEMM = False
+
+requires_fp8 = pytest.mark.skipif(
+    not (
+        _HAS_DEEP_GEMM and torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+    ),
+    reason="FP8 kv_b path requires deep_gemm + Hopper (SM90)+",
+)
+
+
+def record_mla_fp8(ctx: DistributedCtx, req: MLARequest):
+    """
+    Like record_mla but exercises the FP8 in-ring kv_b path. The reference decompresses the
+    latent via an FP8Linear on the *full* sequence (so its kv_b quantization error matches the
+    implementation); the implementation passes the same FP8-quantized kv_b weight into the ring
+    via ``kv_b_quant``. Comparing fp8-vs-fp8 isolates the in-ring math from the (large) e4m3
+    quantization error, so a tight tolerance is meaningful.
+    """
+    from pithtrain.layers.deepgemm_fp8_linear import FP8Linear
+
+    cp_group = ctx.device_mesh.get_group("cp")
+    cp_rank, cp_size = cp_group.rank(), cp_group.size()
+    device = torch.cuda.current_device()
+    H, R = req.H, req.kv_lora_rank
+    nope, rope, vdim = req.qk_nope_head_dim, req.qk_rope_head_dim, req.v_head_dim
+    softmax_scale = (nope + rope) ** -0.5
+    out_features = H * (nope + vdim)
+
+    torch.manual_seed(42)
+    q_nope_full = torch.randn(req.B, req.S, H, nope, device=device, dtype=torch.bfloat16)
+    q_pe_full = torch.randn(req.B, req.S, H, rope, device=device, dtype=torch.bfloat16)
+    normed_kv_full = torch.randn(req.B, req.S, R, device=device, dtype=torch.bfloat16)
+    k_pe_full = torch.randn(req.B, req.S, 1, rope, device=device, dtype=torch.bfloat16)
+    w_full = torch.randn(out_features, R, device=device, dtype=torch.bfloat16) / (R**0.5)
+
+    # Reference: dense full-sequence MLA, no CP, kv_b decompressed via FP8Linear.
+    ref_lin = FP8Linear(R, out_features, bias=False).to(device).to(torch.bfloat16)
+    ref_lin.weight.data.copy_(w_full)
+    q_nope_r = q_nope_full.clone().requires_grad_(True)
+    q_pe_r = q_pe_full.clone().requires_grad_(True)
+    normed_kv_r = normed_kv_full.clone().requires_grad_(True)
+    k_pe_r = k_pe_full.clone().requires_grad_(True)
+    kv = ref_lin(normed_kv_r).view(req.B, req.S, H, nope + vdim)
+    k_nope, value = torch.split(kv, [nope, vdim], dim=-1)
+    out_r = mla_flash_attn_func(
+        q_nope_r,
+        q_pe_r,
+        k_nope.contiguous(),
+        k_pe_r,
+        value.contiguous(),
+        softmax_scale=softmax_scale,
+        qk_nope_head_dim=nope,
+        causal=True,
+    )
+    out_r.sum().backward()
+    ref = MLAResult(
+        extract_zigzag(out_r, cp_rank, cp_size),
+        extract_zigzag(q_nope_r.grad, cp_rank, cp_size),
+        extract_zigzag(q_pe_r.grad, cp_rank, cp_size),
+        extract_zigzag(normed_kv_r.grad, cp_rank, cp_size),
+        extract_zigzag(k_pe_r.grad, cp_rank, cp_size),
+    )
+    dW_ref = ref_lin.weight.grad
+
+    # Implementation: zigzag-local latent rotated around the ring, FP8 in-ring decompress.
+    imp_lin = FP8Linear(R, out_features, bias=False).to(device).to(torch.bfloat16)
+    imp_lin.weight.data.copy_(w_full)
+    kv_b_quant = imp_lin._get_quantized_weight()
+    q_nope_i = extract_zigzag(q_nope_full, cp_rank, cp_size).clone().requires_grad_(True)
+    q_pe_i = extract_zigzag(q_pe_full, cp_rank, cp_size).clone().requires_grad_(True)
+    normed_kv_i = extract_zigzag(normed_kv_full, cp_rank, cp_size).clone().requires_grad_(True)
+    k_pe_i = extract_zigzag(k_pe_full, cp_rank, cp_size).clone().requires_grad_(True)
+    out_i = mla_ring_attention_func(
+        q_nope_i,
+        q_pe_i,
+        normed_kv_i,
+        k_pe_i,
+        imp_lin.weight,
+        sm_scale=softmax_scale,
+        qk_nope_head_dim=nope,
+        v_head_dim=vdim,
+        cp_group=cp_group,
+        kv_b_quant=kv_b_quant,
+    )
+    out_i.sum().backward()
+    imp = MLAResult(out_i, q_nope_i.grad, q_pe_i.grad, normed_kv_i.grad, k_pe_i.grad)
+    # kv_b weight grad is global: sum the per-rank partials across CP (FSDP does this in training).
+    dW_imp = imp_lin.weight.grad.clone()
+    torch.distributed.all_reduce(dW_imp, group=cp_group)
+
+    return ref, imp, dW_ref, dW_imp
+
+
+def verify_mla_fp8(ctx: DistributedCtx, req: MLARequest) -> None:
+    ref, imp, dW_ref, dW_imp = record_mla_fp8(ctx, req)
+    # fp8-vs-fp8 reference: the only differences are the ring vs dense flash recompute order
+    # and per-hop vs whole-sequence activation quant blocking -- both small. Tolerances are
+    # looser than the bf16 test (e4m3 noise) but tight enough to catch a broken fp8 GEMM,
+    # which would give O(1) error.
+    atol_fp8 = 2e-2
+    # dW is the accumulated wgrad over all CP hops; each hop quantizes the activation
+    # to e4m3 at its own block granularity, so the relerr is a few percent (observed
+    # ~3.6e-2). A broken/transposed fp8 GEMM gives O(1) error, so this still catches it.
+    rtol_dW_fp8 = 6e-2
+    for f in fields(ref):
+        error = cosine_error(getattr(ref, f.name), getattr(imp, f.name))
+        if error >= atol_fp8:
+            raise AssertionError(f"[fp8] {f.name} diverged: {error=:.2e} >= {atol_fp8=}")
+    dW_ref_f = dW_ref.to(torch.float32)
+    dW_imp_f = dW_imp.to(torch.float32)
+    werr = cosine_error(dW_ref_f, dW_imp_f)
+    if werr >= atol_fp8:
+        raise AssertionError(f"[fp8] kv_b_weight_grad diverged: {werr=:.2e} >= {atol_fp8=}")
+    rel = ((dW_imp_f - dW_ref_f).norm() / dW_ref_f.norm()).item()
+    if rel >= rtol_dW_fp8:
+        raise AssertionError(
+            f"[fp8] kv_b_weight_grad relerr too large: {rel=:.2e} >= {rtol_dW_fp8=}"
+        )
+
+
+@requires_fp8
+@pytest.mark.parametrize("cp_size,req", MLA_REQUESTS)
+def test_mla_ring_attention_fp8_vs_dense(cp_size: int, req: MLARequest) -> None:
+    cfg = DistributedCfg()
+    cfg.context_parallel_size = cp_size
+    launch(cfg, verify_mla_fp8, req)

--- a/tests/operators/test_ring_attention.py
+++ b/tests/operators/test_ring_attention.py
@@ -345,30 +345,35 @@ def record_mla_fp8(ctx: DistributedCtx, req: MLARequest):
     return ref, imp, dW_ref, dW_imp
 
 
+def _relerr(ref: torch.Tensor, imp: torch.Tensor) -> float:
+    r = ref.to(torch.float32)
+    return ((imp.to(torch.float32) - r).norm() / (r.norm() + 1e-12)).item()
+
+
 def verify_mla_fp8(ctx: DistributedCtx, req: MLARequest) -> None:
     ref, imp, dW_ref, dW_imp = record_mla_fp8(ctx, req)
     # fp8-vs-fp8 reference: the only differences are the ring vs dense flash recompute order
-    # and per-hop vs whole-sequence activation quant blocking -- both small. Tolerances are
-    # looser than the bf16 test (e4m3 noise) but tight enough to catch a broken fp8 GEMM,
-    # which would give O(1) error.
-    atol_fp8 = 2e-2
-    # dW is the accumulated wgrad over all CP hops; each hop quantizes the activation
-    # to e4m3 at its own block granularity, so the relerr is a few percent (observed
-    # ~3.6e-2). A broken/transposed fp8 GEMM gives O(1) error, so this still catches it.
-    rtol_dW_fp8 = 6e-2
+    # and per-hop vs whole-sequence activation quant blocking -- both small. Check BOTH cosine
+    # (direction) AND relative L2 error (magnitude): cosine is scale-invariant and would hide a
+    # uniform fp8 scale bug, so relerr is the one that actually pins down magnitude. Tolerances
+    # are looser than the bf16 test (e4m3 noise) but a broken/transposed fp8 GEMM gives O(1)
+    # error on both, so this still catches it.
+    atol_fp8 = 2e-2  # cosine
+    # relerr is a few percent under fp8 (per-hop e4m3 block quant; dW, summed over all CP hops,
+    # is the worst at ~3.6e-2 observed). A broken fp8 GEMM gives O(1) relerr, so 6e-2 still
+    # catches it while leaving headroom for legitimate quant noise.
+    rtol_fp8 = 6e-2
     for f in fields(ref):
-        error = cosine_error(getattr(ref, f.name), getattr(imp, f.name))
-        if error >= atol_fp8:
-            raise AssertionError(f"[fp8] {f.name} diverged: {error=:.2e} >= {atol_fp8=}")
-    dW_ref_f = dW_ref.to(torch.float32)
-    dW_imp_f = dW_imp.to(torch.float32)
-    werr = cosine_error(dW_ref_f, dW_imp_f)
-    if werr >= atol_fp8:
-        raise AssertionError(f"[fp8] kv_b_weight_grad diverged: {werr=:.2e} >= {atol_fp8=}")
-    rel = ((dW_imp_f - dW_ref_f).norm() / dW_ref_f.norm()).item()
-    if rel >= rtol_dW_fp8:
+        a, b = getattr(ref, f.name), getattr(imp, f.name)
+        cos, rel = cosine_error(a, b), _relerr(a, b)
+        if cos >= atol_fp8 or rel >= rtol_fp8:
+            raise AssertionError(
+                f"[fp8] {f.name} diverged: cosine={cos:.2e} (>={atol_fp8}) relerr={rel:.2e} (>={rtol_fp8})"
+            )
+    cos, rel = cosine_error(dW_ref, dW_imp), _relerr(dW_ref, dW_imp)
+    if cos >= atol_fp8 or rel >= rtol_fp8:
         raise AssertionError(
-            f"[fp8] kv_b_weight_grad relerr too large: {rel=:.2e} >= {rtol_dW_fp8=}"
+            f"[fp8] kv_b_weight_grad diverged: cosine={cos:.2e} (>={atol_fp8}) relerr={rel:.2e} (>={rtol_fp8})"
         )
 
 


### PR DESCRIPTION
Problem:
With `fp8_training="deep-gemm"` and context parallelism (cp>1), MLA attention
takes the pass-latent ring path, which decompressed the rotated latent each hop via
`F.linear(normed_kv, kv_b_proj.weight)` on the bf16 master weight. So kv_b silently ran in
bf16 while every other linear ran fp8: an undocumented precision fallback on the one matmul
unique to the CP path.

Fix:
- `DeepseekV2LiteAttention` pre-quantizes kv_b once per micro-batch via
  `kv_b_proj._get_quantized_weight()` (reusing the `FP8WeightCacheControl` cache) and passes
  the `(weight_fp8, scale_weight, weight_t_fp8, scale_weight_t)` tuple into
  `mla_ring_attention_func(..., kv_b_quant=...)`.
- The in-ring decompress (`_mla_decompress`) and its backward (`mla_zigzag_backward`) gain an
  fp8 branch mirroring `_fp8_linear_fwd/bwd`: rowwise-quantize the latent each hop (it differs
  per hop), then `fp8_fp4_gemm_nt` for fwd / dgrad / wgrad. The bf16 master weight is still
  threaded through so its gradient routes to `kv_b_proj.weight` for FSDP. `kv_b_quant=None`
  leaves the bf16 path unchanged; the `deep_gemm` import is guarded.

Tests:
New `test_mla_ring_attention_fp8_vs_dense` (cp2, cp4) vs a dense `FP8Linear`
reference: forward, all 4 input grads, and dW within fp8 tolerances (cosine < 2e-2; dW relerr
< 6e-2). The 5 existing bf16 ring cases are unchanged. All 7 pass.