### PR TITLE
Add wsd support

### DIFF
--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -46,8 +46,9 @@ class TrainingCfg(SlottedDefault):
     max_lr: float
     """The maximum learning rate."""
 
-    warmup_steps: int
-    """The number of steps for linear warmup of the learning rate."""
+    warmup_steps: int = 0
+    """The number of steps for linear warmup of the learning rate; 0 (the default) disables
+    warmup, e.g. for a mid-training decay run that plugs into an existing checkpoint."""
 
     max_steps: int
     """The maximum number of training steps."""
@@ -68,12 +69,12 @@ class TrainingCfg(SlottedDefault):
     scheduler: Literal["CosineAnnealing", "Constant", "WSD"]
     """The learning rate scheduler to use after linear warmup."""
 
-    decay_type: Literal["linear", "cosine"] = "cosine"
+    wsd_decay_type: Literal["linear", "cosine"] = "cosine"
     """Shape of the WSD decay tail. Only used when ``scheduler == "WSD"``."""
 
-    decay_steps: int = 0
+    wsd_decay_steps: int = 0
     """Number of steps in the WSD decay tail; the stable phase is the remainder
-    (``max_steps - warmup_steps - decay_steps``). Only used when ``scheduler == "WSD"``."""
+    (``max_steps - warmup_steps - wsd_decay_steps``). Only used when ``scheduler == "WSD"``."""
 
     model: Union[
         Path,
@@ -437,30 +438,31 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
         case "Constant":
             phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, post_steps))
         case "WSD":
-            # warmup -> stable (hold max_lr) -> decay (max_lr to min_lr) over decay_steps.
-            # Bound decay_steps so both the stable and decay phases are non-degenerate:
-            # 0-length phases give SequentialLR a zero T_max/total_iters (ZeroDivisionError)
-            # or non-increasing milestones (silently wrong LR).
-            if not 0 < cfg.decay_steps < post_steps:
+            # warmup -> stable (hold max_lr) -> decay (max_lr to min_lr) over wsd_decay_steps.
+            # Bound it so both the stable and decay phases are non-degenerate: 0-length phases
+            # give SequentialLR a zero T_max/total_iters (ZeroDivisionError) or non-increasing
+            # milestones (silently wrong LR).
+            if not 0 < cfg.wsd_decay_steps < post_steps:
                 raise ValueError(
-                    f"WSD needs 0 < decay_steps < max_steps - warmup_steps; got "
-                    f"decay_steps={cfg.decay_steps}, warmup_steps={warmup_steps}, max_steps={max_steps}"
+                    f"WSD needs 0 < wsd_decay_steps < max_steps - warmup_steps; got "
+                    f"wsd_decay_steps={cfg.wsd_decay_steps}, warmup_steps={warmup_steps}, "
+                    f"max_steps={max_steps}"
                 )
-            stable_steps = post_steps - cfg.decay_steps
+            stable_steps = post_steps - cfg.wsd_decay_steps
             phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, stable_steps))
-            match cfg.decay_type:
+            match cfg.wsd_decay_type:
                 case "linear":
-                    phases.append(LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.decay_steps))
+                    phases.append(
+                        LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.wsd_decay_steps)
+                    )
                 case "cosine":
-                    phases.append(CosineAnnealingLR(ctx.optimizer, cfg.decay_steps, min_lr))
+                    phases.append(CosineAnnealingLR(ctx.optimizer, cfg.wsd_decay_steps, min_lr))
                 case _:
-                    raise ValueError(f"Unknown decay_type: {cfg.decay_type!r}")
+                    raise ValueError(f"Unknown wsd_decay_type: {cfg.wsd_decay_type!r}")
             milestones.append(warmup_steps + stable_steps)
         case _:
             raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")
-    ctx.scheduler = (
-        SequentialLR(ctx.optimizer, phases, milestones) if len(phases) > 1 else phases[0]
-    )
+    ctx.scheduler = SequentialLR(ctx.optimizer, phases, milestones)
 
 
 @contextmanager

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -419,16 +419,29 @@ def setup_optimizer(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
 def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
     min_lr, max_lr = cfg.min_lr, cfg.max_lr
     warmup_steps, max_steps = cfg.warmup_steps, cfg.max_steps
-    warmup = LinearLR(ctx.optimizer, min_lr / max_lr, 1.0, warmup_steps)
-    phases, milestones = [warmup], [warmup_steps]
+    post_steps = max_steps - warmup_steps
+    # Linear warmup min_lr -> max_lr. Skipped when warmup_steps == 0: a zero-length
+    # LinearLR is degenerate and would otherwise pin the following phase at min_lr.
+    phases, milestones = [], []
+    if warmup_steps > 0:
+        phases.append(LinearLR(ctx.optimizer, min_lr / max_lr, 1.0, warmup_steps))
+        milestones.append(warmup_steps)
     match cfg.scheduler:
         case "CosineAnnealing":
-            phases.append(CosineAnnealingLR(ctx.optimizer, max_steps - warmup_steps, min_lr))
+            phases.append(CosineAnnealingLR(ctx.optimizer, post_steps, min_lr))
         case "Constant":
-            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, max_steps - warmup_steps))
+            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, post_steps))
         case "WSD":
             # warmup -> stable (hold max_lr) -> decay (max_lr to min_lr) over decay_steps.
-            stable_steps = max_steps - warmup_steps - cfg.decay_steps
+            # Bound decay_steps so both the stable and decay phases are non-degenerate:
+            # 0-length phases give SequentialLR a zero T_max/total_iters (ZeroDivisionError)
+            # or non-increasing milestones (silently wrong LR).
+            if not 0 < cfg.decay_steps < post_steps:
+                raise ValueError(
+                    f"WSD needs 0 < decay_steps < max_steps - warmup_steps; got "
+                    f"decay_steps={cfg.decay_steps}, warmup_steps={warmup_steps}, max_steps={max_steps}"
+                )
+            stable_steps = post_steps - cfg.decay_steps
             phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, stable_steps))
             phases.append(
                 LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.decay_steps)
@@ -438,7 +451,9 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
             milestones.append(warmup_steps + stable_steps)
         case _:
             raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")
-    ctx.scheduler = SequentialLR(ctx.optimizer, phases, milestones)
+    ctx.scheduler = (
+        SequentialLR(ctx.optimizer, phases, milestones) if len(phases) > 1 else phases[0]
+    )
 
 
 @contextmanager

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -420,6 +420,11 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
     min_lr, max_lr = cfg.min_lr, cfg.max_lr
     warmup_steps, max_steps = cfg.warmup_steps, cfg.max_steps
     post_steps = max_steps - warmup_steps
+    if post_steps <= 0:
+        raise ValueError(
+            f"max_steps must be greater than warmup_steps; got "
+            f"max_steps={max_steps}, warmup_steps={warmup_steps}"
+        )
     # Linear warmup min_lr -> max_lr. Skipped when warmup_steps == 0: a zero-length
     # LinearLR is degenerate and would otherwise pin the following phase at min_lr.
     phases, milestones = [], []
@@ -443,11 +448,13 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
                 )
             stable_steps = post_steps - cfg.decay_steps
             phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, stable_steps))
-            phases.append(
-                LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.decay_steps)
-                if cfg.decay_type == "linear"
-                else CosineAnnealingLR(ctx.optimizer, cfg.decay_steps, min_lr)
-            )
+            match cfg.decay_type:
+                case "linear":
+                    phases.append(LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.decay_steps))
+                case "cosine":
+                    phases.append(CosineAnnealingLR(ctx.optimizer, cfg.decay_steps, min_lr))
+                case _:
+                    raise ValueError(f"Unknown decay_type: {cfg.decay_type!r}")
             milestones.append(warmup_steps + stable_steps)
         case _:
             raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -65,8 +65,15 @@ class TrainingCfg(SlottedDefault):
     optimizer: Literal["Adam"]
     """The optimizer to use during training."""
 
-    scheduler: Literal["CosineAnnealing", "Constant"]
+    scheduler: Literal["CosineAnnealing", "Constant", "WSD"]
     """The learning rate scheduler to use after linear warmup."""
+
+    decay_type: Literal["linear", "cosine"] = "cosine"
+    """Shape of the WSD decay tail. Only used when ``scheduler == "WSD"``."""
+
+    decay_steps: int = 0
+    """Number of steps in the WSD decay tail; the stable phase is the remainder
+    (``max_steps - warmup_steps - decay_steps``). Only used when ``scheduler == "WSD"``."""
 
     model: Union[
         Path,
@@ -413,14 +420,25 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
     min_lr, max_lr = cfg.min_lr, cfg.max_lr
     warmup_steps, max_steps = cfg.warmup_steps, cfg.max_steps
     warmup = LinearLR(ctx.optimizer, min_lr / max_lr, 1.0, warmup_steps)
+    phases, milestones = [warmup], [warmup_steps]
     match cfg.scheduler:
         case "CosineAnnealing":
-            stable = CosineAnnealingLR(ctx.optimizer, max_steps - warmup_steps, min_lr)
+            phases.append(CosineAnnealingLR(ctx.optimizer, max_steps - warmup_steps, min_lr))
         case "Constant":
-            stable = LinearLR(ctx.optimizer, 1.0, 1.0, max_steps - warmup_steps)
+            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, max_steps - warmup_steps))
+        case "WSD":
+            # warmup -> stable (hold max_lr) -> decay (max_lr to min_lr) over decay_steps.
+            stable_steps = max_steps - warmup_steps - cfg.decay_steps
+            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, stable_steps))
+            phases.append(
+                LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.decay_steps)
+                if cfg.decay_type == "linear"
+                else CosineAnnealingLR(ctx.optimizer, cfg.decay_steps, min_lr)
+            )
+            milestones.append(warmup_steps + stable_steps)
         case _:
             raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")
-    ctx.scheduler = SequentialLR(ctx.optimizer, [warmup, stable], [warmup_steps])
+    ctx.scheduler = SequentialLR(ctx.optimizer, phases, milestones)
 
 
 @contextmanager

--- a/pithtrain/tasks/pretrain_lm.py
+++ b/pithtrain/tasks/pretrain_lm.py
@@ -23,7 +23,7 @@ from torch.distributed.checkpoint.state_dict import (
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import LRScheduler
+from torch.optim.lr_scheduler import CosineAnnealingLR, LRScheduler
 
 from pithtrain.config import SlottedDefault
 from pithtrain.modules.checkpoint import (
@@ -166,8 +166,9 @@ def clip_grad_norm_(model: nn.Module, max_norm: float, norm_type: float = 2.0) -
 def _scheduler_structure_mismatch(state: dict, sched: LRScheduler) -> bool:
     """True if a saved scheduler state_dict has a different structure than the live scheduler
     (phase count or per-phase type), which torch's load_state_dict would silently corrupt.
-    Recurses into SequentialLR children and distinguishes CosineAnnealingLR (has ``T_max``)
-    from LinearLR -- the two leaf schedulers ``setup_scheduler`` builds."""
+    Recurses into SequentialLR children; at the leaves the saved type is inferred from its
+    state keys (only CosineAnnealingLR carries ``T_max``) and compared to the live scheduler's
+    class -- CosineAnnealingLR vs LinearLR are the two leaf types ``setup_scheduler`` builds."""
     has_state_subs = "_schedulers" in state
     has_sched_subs = hasattr(sched, "_schedulers")
     if has_state_subs != has_sched_subs:
@@ -177,7 +178,7 @@ def _scheduler_structure_mismatch(state: dict, sched: LRScheduler) -> bool:
         if len(subs_state) != len(subs_sched):
             return True
         return any(_scheduler_structure_mismatch(s, c) for s, c in zip(subs_state, subs_sched))
-    return ("T_max" in state) != hasattr(sched, "T_max")
+    return ("T_max" in state) != isinstance(sched, CosineAnnealingLR)
 
 
 class AppState(Stateful):
@@ -241,10 +242,6 @@ class AppState(Stateful):
             options = StateDictOptions(strict=False)
             set_model_state_dict(self.model, model_state, options=options)
         if sched_state:
-            # A scheduler's structure (phase count AND per-phase type) depends on the config
-            # (warmup / scheduler / WSD decay shape). torch load_state_dict just updates
-            # __dict__, so loading a mismatched structure silently corrupts the LR or crashes;
-            # refuse any structural/type mismatch with a clear message instead.
             if _scheduler_structure_mismatch(sched_state, self.scheduler):
                 raise ValueError(
                     "Checkpoint scheduler structure does not match the current config; "

--- a/pithtrain/tasks/pretrain_lm.py
+++ b/pithtrain/tasks/pretrain_lm.py
@@ -224,6 +224,18 @@ class AppState(Stateful):
             options = StateDictOptions(strict=False)
             set_model_state_dict(self.model, model_state, options=options)
         if sched_state:
+            # The scheduler is a SequentialLR whose phase count depends on the config
+            # (warmup/scheduler/WSD-decay). Loading a saved phase list into a differently
+            # shaped scheduler silently corrupts the LR (or raises IndexError), so refuse a
+            # structural mismatch with a clear message instead.
+            saved_n = len(sched_state.get("_schedulers", []))
+            cur_n = len(getattr(self.scheduler, "_schedulers", []))
+            if saved_n != cur_n:
+                raise ValueError(
+                    f"Checkpoint scheduler has {saved_n} phase(s) but the current config "
+                    f"builds {cur_n}; resuming across a scheduler/warmup/decay change is not "
+                    f"supported. Resume with the same scheduler config, or train from scratch."
+                )
             self.scheduler.load_state_dict(sched_state)
 
 

--- a/pithtrain/tasks/pretrain_lm.py
+++ b/pithtrain/tasks/pretrain_lm.py
@@ -163,6 +163,23 @@ def clip_grad_norm_(model: nn.Module, max_norm: float, norm_type: float = 2.0) -
     return total_norm
 
 
+def _scheduler_structure_mismatch(state: dict, sched: LRScheduler) -> bool:
+    """True if a saved scheduler state_dict has a different structure than the live scheduler
+    (phase count or per-phase type), which torch's load_state_dict would silently corrupt.
+    Recurses into SequentialLR children and distinguishes CosineAnnealingLR (has ``T_max``)
+    from LinearLR -- the two leaf schedulers ``setup_scheduler`` builds."""
+    has_state_subs = "_schedulers" in state
+    has_sched_subs = hasattr(sched, "_schedulers")
+    if has_state_subs != has_sched_subs:
+        return True
+    if has_state_subs:
+        subs_state, subs_sched = state["_schedulers"], sched._schedulers
+        if len(subs_state) != len(subs_sched):
+            return True
+        return any(_scheduler_structure_mismatch(s, c) for s, c in zip(subs_state, subs_sched))
+    return ("T_max" in state) != hasattr(sched, "T_max")
+
+
 class AppState(Stateful):
     """Stateful object to save and load the checkpoint."""
 
@@ -224,17 +241,15 @@ class AppState(Stateful):
             options = StateDictOptions(strict=False)
             set_model_state_dict(self.model, model_state, options=options)
         if sched_state:
-            # The scheduler is a SequentialLR whose phase count depends on the config
-            # (warmup/scheduler/WSD-decay). Loading a saved phase list into a differently
-            # shaped scheduler silently corrupts the LR (or raises IndexError), so refuse a
-            # structural mismatch with a clear message instead.
-            saved_n = len(sched_state.get("_schedulers", []))
-            cur_n = len(getattr(self.scheduler, "_schedulers", []))
-            if saved_n != cur_n:
+            # A scheduler's structure (phase count AND per-phase type) depends on the config
+            # (warmup / scheduler / WSD decay shape). torch load_state_dict just updates
+            # __dict__, so loading a mismatched structure silently corrupts the LR or crashes;
+            # refuse any structural/type mismatch with a clear message instead.
+            if _scheduler_structure_mismatch(sched_state, self.scheduler):
                 raise ValueError(
-                    f"Checkpoint scheduler has {saved_n} phase(s) but the current config "
-                    f"builds {cur_n}; resuming across a scheduler/warmup/decay change is not "
-                    f"supported. Resume with the same scheduler config, or train from scratch."
+                    "Checkpoint scheduler structure does not match the current config; "
+                    "resuming across a scheduler/warmup/decay change is not supported. "
+                    "Resume with the same scheduler config, or train from scratch."
                 )
             self.scheduler.load_state_dict(sched_state)
 


### PR DESCRIPTION
- Add WSD (warmup-stable-decay) LR schedule: scheduler="WSD" holds max_lr, then decays to min_lr over the last decay_steps, shape picked by decay_type (linear/cosine).
- Validate decay_steps (0 < decay_steps < max_steps − warmup_steps) so a bad value fails fast at startup instead of crashing near the end or silently pinning the LR.
- Fix warmup_steps=0 — it used to hold the whole run at min_lr; now it starts at max_lr (also fixes Constant/Cosine, and makes warmup-free decay-from-a-checkpoint work).
- Resuming a checkpoint under a different scheduler shape now raises a clear error instead of an IndexError / silently-wrong LR. 
- CosineAnnealing/Constant paths unchanged; verified across pp/dp/cp/ep meshes and both decay shapes.
