### PR TITLE
Exclude redundant cutlass-dsl base wheel to fix FA4 JIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ requires = ["setuptools>=61"]
 include = ["pithtrain*"]
 
 [tool.uv]
+# Exclude the redundant `-libs-base` wheel. It and `-libs-cu13` ship the same file
+# paths with different content, so a parallel `uv sync` can race into a broken mix
+# that breaks FA4's cute-dsl JIT (depends on the install filesystem, not the Python
+# version). cu13 is a strict superset of base, so nothing is lost. NVIDIA/cutlass#3259.
+# `override-dependencies` with a never-true marker is uv's idiom for dropping a dep.
+override-dependencies = [
+    "nvidia-cutlass-dsl-libs-base; python_version < '0'",
+]
 
 [[tool.uv.index]]
 name = "torch-cu130"


### PR DESCRIPTION
`nvidia-cutlass-dsl-libs-base` and `-libs-cu13` declare the same file paths with
different content (the MLIR `.so`, `_mlir` bindings, and `tvm_ffi_provider.py`).
A parallel `uv sync` extracts the two wheels in a racy order and can leave a
mismatched mix — e.g. the cu13 `.so` paired with the stale base provider — which
breaks FlashAttention-4's cute-dsl JIT with `mlir_global_dtors() missing 1
required positional argument: 'data'`. Whether it breaks depends on the install
filesystem (NFS tends to race, local disks tend not to), not the Python version,
so it reproduces intermittently across machines.

`-libs-cu13` is a strict superset of `-libs-base` (only a duplicate LICENSE
differs), so add a `[tool.uv]` override that excludes the redundant base wheel via
an always-false marker. This removes the overlap entirely, leaving cu13's correct
files as the only copies on every filesystem and Python version. Drop the override
once upstream stops shipping overlapping wheels (NVIDIA/cutlass#3259).

Migration: an existing venv that still has base installed needs a one-time
`uv sync --reinstall-package nvidia-cutlass-dsl-libs-cu13` (or a fresh `.venv`)
after this change; new environments are unaffected.