### PR TITLE
Add Muon optimizer composed with an auxiliary AdamW

### DIFF
--- a/pithtrain/modules/checkpoint.py
+++ b/pithtrain/modules/checkpoint.py
@@ -219,14 +219,45 @@ def to_canonical_model(
     return unpack(state_dict, dict(model.named_modules()), lambda v, n, i: v[i])
 
 
+def _expand_local_fqn(local_fqn: str, named_modules: Dict[str, nn.Module]) -> list:
+    """Map a local (runtime) FQN to its canonical (disk) FQN(s), expanding
+    stacked experts."""
+    canon = strip_prefix(local_fqn)
+    moe = find_moe(local_fqn, named_modules)
+    if moe is None:
+        return [canon]
+    start, end = expert_range(moe)
+    return [canon.replace(".experts.", ".experts.%d." % idx, 1) for idx in range(start, end)]
+
+
+def _local_param_group_fqns(model: nn.Module, optimizers) -> list:
+    """This rank's local FQNs per param group, across ``optimizers`` in order
+    (the order DCP combines them in). Needed on load: DCP dedups param_groups
+    metadata across PP ranks, so the loaded params lists aren't reliably this
+    rank's -- we rebuild membership from the live optimizers instead."""
+    param_to_fqn = {p: n for n, p in model.named_parameters()}
+    groups = []
+    for opt in optimizers:
+        for g in opt.param_groups:
+            groups.append([param_to_fqn[p] for p in g["params"]])
+    return groups
+
+
 def to_canonical_optim(optim_state: Dict, model: nn.Module) -> Dict:
-    """Canonicalize optimizer state: strip module prefix, unstack expert states."""
-    state = unpack(optim_state["state"], dict(model.named_modules()), unstack_optim)
-    params = list(state.keys())
+    """Canonicalize optimizer state: strip module prefix, unstack expert states.
+
+    Each param group keeps its *own* membership (its loaded FQNs mapped to
+    canonical, experts expanded) rather than collapsing to the full param set, so a
+    composed multi-optimizer state dict (Muon + AdamW, combined by DCP) round-trips
+    without one group's hyperparameters leaking onto another's. Plain Adam is the
+    degenerate case: its one group already owns every param.
+    """
+    named_modules = dict(model.named_modules())
+    state = unpack(optim_state["state"], named_modules, unstack_optim)
     param_groups = []
     for g in optim_state["param_groups"]:
         group = {k: v for k, v in g.items() if k != "params"}
-        group["params"] = params
+        group["params"] = [cf for lf in g["params"] for cf in _expand_local_fqn(lf, named_modules)]
         param_groups.append(group)
     return {"state": state, "param_groups": param_groups}
 
@@ -280,23 +311,29 @@ def to_localized_model(
     return result
 
 
-def to_localized_optim(optim_state: Dict, model: nn.Module) -> Dict:
+def to_localized_optim(optim_state: Dict, model: nn.Module, optimizers) -> Dict:
     """
     Localize optimizer state: remap FQNs, restack experts, rebuild param_groups.
 
-    The param_groups are rebuilt with ALL of the current model's local FQNs
-    (ignoring the loaded params lists) because DCP deduplicates non-tensor
-    metadata across PP ranks.  Hyperparameters (lr, betas, ...) are taken from
-    the loaded param_groups.
+    Membership is rebuilt from the live ``optimizers`` (DCP dedups param_groups
+    across PP ranks, so the loaded lists aren't reliably this rank's). Each loaded
+    group is matched by position to the live group (the order DCP combined them
+    in); its hyperparameters are kept, its membership replaced with that group's
+    local FQNs.
     """
     named_modules = dict(model.named_modules())
     fqn_map = {strip_prefix(n): n for n, _ in model.named_parameters()}
     state = repack(optim_state["state"], fqn_map, named_modules, restack_optim)
     rewrap_dtensor_experts(state, model)
-    all_local = list(fqn_map.values())
+    local_groups = _local_param_group_fqns(model, optimizers)
+    loaded_groups = optim_state["param_groups"]
+    assert len(loaded_groups) == len(local_groups), (
+        f"param_group count mismatch: checkpoint has {len(loaded_groups)}, "
+        f"live optimizers have {len(local_groups)}"
+    )
     param_groups = []
-    for g in optim_state["param_groups"]:
+    for g, members in zip(loaded_groups, local_groups):
         group = {k: v for k, v in g.items() if k != "params"}
-        group["params"] = all_local
+        group["params"] = members
         param_groups.append(group)
     return {"state": state, "param_groups": param_groups}

--- a/pithtrain/modules/optimizer/__init__.py
+++ b/pithtrain/modules/optimizer/__init__.py
@@ -1,0 +1,18 @@
+"""Optimizers. Muon is composed with a separate auxiliary optimizer (a plain
+``torch.optim`` one); future optimizers live alongside ``muon`` here."""
+
+from pithtrain.modules.optimizer.muon import (
+    Muon,
+    is_muon_param,
+    muon_scale_factor,
+    partition_muon_params,
+    zeropower_via_newtonschulz5,
+)
+
+__all__ = [
+    "Muon",
+    "is_muon_param",
+    "muon_scale_factor",
+    "partition_muon_params",
+    "zeropower_via_newtonschulz5",
+]

--- a/pithtrain/modules/optimizer/muon.py
+++ b/pithtrain/modules/optimizer/muon.py
@@ -1,0 +1,250 @@
+"""
+Muon optimizer: SGD momentum, then orthogonalize the update with a 5-step
+Newton-Schulz iteration.
+
+Only 2D hidden weights are Muon-eligible (:func:`is_muon_param`); embeddings,
+the LM head, norms, biases, and the MoE router go to a separate AdamW.
+:func:`partition_muon_params` splits a model into the two lists; the training
+setup composes ``[Muon, AdamW]`` and steps/schedules/checkpoints them together.
+
+Under FSDP2 a weight is a sharded DTensor and Newton-Schulz needs the full
+matrix. Instead of every rank gathering and orthogonalizing every weight
+(duplicating the compute G times, G = FSDP group size),
+:func:`orthogonalized_updates` round-robins the weights across the mesh so
+each rank does ~1/G of them and broadcasts the result -- a bit-identical update
+(NS is deterministic on the gathered matrix), faster as G grows. G==1 weights
+are done locally.
+
+The update is scaled by Moonlight's ``0.2 * sqrt(max(n, m))`` so its RMS
+matches AdamW's and both share one LR. ``zeropower_via_newtonschulz5`` is
+verbatim from the public reference (mirrored by DeepSpeed).
+"""
+
+import math
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor, Replicate
+
+# ---------------------------------------------------------------------------
+# Newton-Schulz orthogonalization
+# ---------------------------------------------------------------------------
+
+
+def zeropower_via_newtonschulz5(G: torch.Tensor, steps: int) -> torch.Tensor:
+    """Quintic Newton-Schulz orthogonalization, batched over leading dims, bf16.
+
+    Drives singular values toward ~1 (not exactly UV^T, but close enough). The
+    transpose handles tall matrices; the Frobenius prescale keeps spectral norm
+    <= 1.
+    """
+    assert G.ndim >= 2  # batches over leading dims (e.g. 3D stacked experts)
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A  # quintic update term
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+def muon_scale_factor(n: int, m: int) -> float:
+    """Moonlight scale ``0.2 * sqrt(max(n, m))``: brings the orthogonalized
+    update's RMS to ~0.2 (~ an AdamW step) so Muon and AdamW share one LR."""
+    return 0.2 * max(n, m) ** 0.5
+
+
+# ---------------------------------------------------------------------------
+# Distributed orthogonalization (parameter-parallel Newton-Schulz)
+#
+# Round-robin the weights across each one's FSDP mesh so the compute-bound NS
+# is shared, not duplicated on every rank. Within a chunk: gather every weight,
+# then each rank orthogonalizes only the ones it owns, then broadcast the
+# results -- with no collective between the orthogonalizations, so they run
+# concurrently across ranks instead of being serialized. Chunking bounds memory.
+# ---------------------------------------------------------------------------
+
+
+def _orthogonalize(full, dtype, steps):
+    orth = zeropower_via_newtonschulz5(full, steps=steps).to(dtype)
+    return (orth * muon_scale_factor(full.size(-2), full.size(-1))).contiguous()
+
+
+def _broadcast_owned(results, updates, params, idxs, owner_of, group, group_size):
+    """Broadcast the per-owner results so every rank ends up with all of them.
+    Each rank concatenates the weights it owns into one buffer and broadcasts it
+    once; the others pre-size the buffer from each weight's ``.shape``/dtype and
+    slice it back out (N -> G collectives). Assumes one dtype per mesh group."""
+    group_rank = dist.get_rank(group)
+    for owner in range(group_size):
+        owned = [i for i in idxs if owner_of[i] == owner]
+        if not owned:
+            continue
+        shapes = [tuple(updates[i].shape) for i in owned]
+        numels = [math.prod(s) for s in shapes]
+        dtype, device = params[owned[0]].dtype, params[owned[0]].device
+        if group_rank == owner:
+            flat = torch.cat([results[i].reshape(-1) for i in owned])
+        else:
+            flat = torch.empty(sum(numels), dtype=dtype, device=device)
+        dist.broadcast(flat, src=dist.get_global_rank(group, owner), group=group)
+        offset = 0
+        for i, shape, numel in zip(owned, shapes, numels):
+            results[i] = flat[offset : offset + numel].view(shape)
+            offset += numel
+
+
+def orthogonalized_updates(params, updates, steps: int = 5, chunk_size: int | None = None):
+    """Orthogonalize each ``updates[i]`` (post-momentum, DTensor or plain),
+    distributing the NS across each weight's 1-D FSDP mesh. Returns the full
+    orthogonalized+scaled tensor per weight (in ``params[i].dtype``); the caller
+    reshards/applies it."""
+    results = [None] * len(updates)
+
+    # Bucket sharded (G>1) weights by mesh group; the rest are local.
+    buckets: dict[int, tuple] = {}  # group id -> (group, G, rank, idxs)
+    local = []
+    for i, u in enumerate(updates):
+        if isinstance(u, DTensor) and u.device_mesh.ndim == 1:
+            group = u.device_mesh.get_group()
+            if dist.get_world_size(group) > 1:
+                key = id(group)
+                if key not in buckets:
+                    buckets[key] = (group, dist.get_world_size(group), dist.get_rank(group), [])
+                buckets[key][3].append(i)
+                continue
+        local.append(i)
+
+    # Local weights (plain or G==1): no duplication, orthogonalize in place.
+    for i in local:
+        u = updates[i]
+        full = u.full_tensor() if isinstance(u, DTensor) else u
+        results[i] = _orthogonalize(full, params[i].dtype, steps)
+
+    for group, group_size, group_rank, idxs in buckets.values():
+        chunk = chunk_size or max(4 * group_size, 8)
+        owner_of = {idx: pos % group_size for pos, idx in enumerate(idxs)}
+        for start in range(0, len(idxs), chunk):
+            window = idxs[start : start + chunk]
+            # Gather the chunk; each rank orthogonalizes the weights it owns.
+            fulls = {i: updates[i].full_tensor() for i in window}
+            for i in window:
+                if owner_of[i] == group_rank:
+                    results[i] = _orthogonalize(fulls[i], params[i].dtype, steps)
+            fulls.clear()
+        # Broadcast so every rank ends up with all the orthogonalized weights.
+        _broadcast_owned(results, updates, params, idxs, owner_of, group, group_size)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# The Muon optimizer
+# ---------------------------------------------------------------------------
+
+
+class Muon(torch.optim.Optimizer):
+    """Muon for 2D (and batched-3D-expert) hidden weights. One fp32
+    ``momentum_buffer`` per param; each step is momentum -> Newton-Schulz ->
+    scale. Pass only Muon-eligible params (:func:`is_muon_param`)."""
+
+    def __init__(self, params, lr: float = 0.02, momentum: float = 0.95, weight_decay: float = 0.0):
+        defaults = dict(lr=lr, momentum=momentum, weight_decay=weight_decay)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        # Compute every update first, then orthogonalize the batch together so
+        # the per-mesh round-robin and broadcasts stay in lockstep across ranks.
+        params, updates, hparams = [], [], []
+        for group in self.param_groups:
+            beta, lr, wd = group["momentum"], group["lr"], group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                params.append(p)
+                updates.append(self._compute_update(p, beta))
+                hparams.append((lr, wd))
+
+        if params:
+            orths = orthogonalized_updates(params, updates, steps=5)
+            for p, orth, (lr, wd) in zip(params, orths, hparams):
+                self._apply(p, orth, lr, wd)
+
+        return loss
+
+    def _compute_update(self, p, beta):
+        """SGD momentum on the local shard (no comm); returns the pre-NS update.
+        Grad is cast to fp32 to match the fp32 momentum buffer (grads may be
+        bf16)."""
+        state = self.state[p]
+        if len(state) == 0:
+            state["momentum_buffer"] = torch.zeros_like(p, dtype=torch.float32)
+        buf = state["momentum_buffer"]
+        grad = p.grad.to(torch.float32)
+        buf.lerp_(grad, 1 - beta)
+        return grad.lerp(buf, beta)
+
+    def _apply(self, p, orth, lr, wd):
+        """Decoupled weight decay + the step. ``orth`` is the full update;
+        reshard to ``p``'s placements (a local narrow) when ``p`` is sharded."""
+        if isinstance(p, DTensor):
+            replicated = [Replicate()] * p.device_mesh.ndim
+            orth = DTensor.from_local(
+                orth, p.device_mesh, replicated, run_check=False
+            ).redistribute(placements=p.placements)
+        p.mul_(1 - lr * wd)
+        p.add_(orth, alpha=-lr)
+
+
+# ---------------------------------------------------------------------------
+# Parameter classification
+# ---------------------------------------------------------------------------
+
+
+def is_muon_param(name: str, param: torch.Tensor) -> bool:
+    """True if ``param`` is a 2D hidden weight Muon should optimize.
+
+    Muon: attention q/k/v/o and MLA projections, dense/shared-expert
+    gate/up/down, and the stacked 3D expert weights. AdamW (False): all 1D
+    params (norms, biases, sinks), embeddings, the LM head, the MoE gate/router,
+    and the 2D stacked expert biases (caught by the ``_bias`` check).
+    """
+    if param.ndim < 2:
+        return False
+    if name.endswith(".bias") or name.endswith("_bias"):
+        return False
+    if name.endswith("embed_tokens.weight") or name.endswith("lm_head.weight"):
+        return False
+    if ".gate.weight" in name or ".router.weight" in name:
+        return False
+    return True
+
+
+def partition_muon_params(model: torch.nn.Module):
+    """Split ``model``'s requires-grad params into ``(muon_params, aux_params)``
+    via :func:`is_muon_param`. Asserts the Muon list is non-empty."""
+    muon_params, aux_params = [], []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        (muon_params if is_muon_param(name, param) else aux_params).append(param)
+
+    assert muon_params, (
+        "Muon selected no parameters; check the model classification in is_muon_param."
+    )
+    return muon_params, aux_params

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -14,7 +14,7 @@ import torch.distributed.fsdp
 import torch.nn as nn
 from torch.distributed import DeviceMesh
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-from torch.optim import Adam, Optimizer
+from torch.optim import Adam, AdamW, Optimizer
 from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 from transformers import AutoConfig
 
@@ -25,6 +25,7 @@ from pithtrain.models.gpt_oss import GptOssModel
 from pithtrain.models.qwen3_moe import Qwen3MoeModel
 from pithtrain.modules.dataset import ConcatDataset, MemmapDataset
 from pithtrain.modules.load_balance import make_load_balance_loss_fn
+from pithtrain.modules.optimizer import Muon, partition_muon_params
 
 from .distributed import DistributedCfg, DistributedCtx
 
@@ -63,8 +64,15 @@ class TrainingCfg(SlottedDefault):
     Gradients will be accumulated over multiple micro-batches to achieve this batch size.
     """
 
-    optimizer: Literal["Adam"]
-    """The optimizer to use during training."""
+    optimizer: Literal["Adam", "Muon"]
+    """
+    The optimizer to use during training.
+
+    * "Adam" - Adam over all parameters.
+    * "Muon" - Muon for 2D hidden weights, composed with a built-in AdamW for
+      everything else (embeddings, LM head, norms, biases, MoE router); the two
+      are stepped and scheduled together as a list.
+    """
 
     scheduler: Literal["CosineAnnealing", "Constant", "WSD"]
     """The learning rate scheduler to use after linear warmup."""
@@ -189,11 +197,11 @@ class TrainingCtx:
     model: DualPipeV
     """The model being trained."""
 
-    optimizer: Optimizer
-    """The optimizer used for training."""
+    optimizers: tuple[Optimizer, ...]
+    """Optimizer(s): Muon composes two (Muon + AdamW); Adam is a 1-tuple."""
 
-    scheduler: LRScheduler
-    """The learning rate scheduler used for training."""
+    schedulers: tuple[LRScheduler, ...]
+    """Scheduler(s), one per optimizer (same warmup/decay shape)."""
 
     step: int
     """The current training step."""
@@ -414,7 +422,19 @@ def setup_model(
 
 def setup_optimizer(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
     model, max_lr = ctx.model, cfg.max_lr
-    ctx.optimizer = Adam(model.parameters(), lr=max_lr)
+    match cfg.optimizer:
+        case "Adam":
+            ctx.optimizers = (Adam(model.parameters(), lr=max_lr),)
+        case "Muon":
+            # Muon for hidden weights, AdamW for the rest; weight_decay=0.0
+            # keeps the shared-LR scheme with Muon.
+            muon_params, aux_params = partition_muon_params(model)
+            ctx.optimizers = (
+                Muon(muon_params, lr=max_lr),
+                AdamW(aux_params, lr=max_lr, weight_decay=0.0),
+            )
+        case _:
+            raise ValueError(f"Unknown optimizer: {cfg.optimizer!r}")
 
 
 def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
@@ -426,43 +446,48 @@ def setup_scheduler(cfg: TrainingCfg, ctx: TrainingCtx) -> None:
             f"max_steps must be greater than warmup_steps; got "
             f"max_steps={max_steps}, warmup_steps={warmup_steps}"
         )
-    # Linear warmup min_lr -> max_lr. Skipped when warmup_steps == 0: a zero-length
-    # LinearLR is degenerate and would otherwise pin the following phase at min_lr.
-    phases, milestones = [], []
-    if warmup_steps > 0:
-        phases.append(LinearLR(ctx.optimizer, min_lr / max_lr, 1.0, warmup_steps))
-        milestones.append(warmup_steps)
-    match cfg.scheduler:
-        case "CosineAnnealing":
-            phases.append(CosineAnnealingLR(ctx.optimizer, post_steps, min_lr))
-        case "Constant":
-            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, post_steps))
-        case "WSD":
-            # warmup -> stable (hold max_lr) -> decay (max_lr to min_lr) over wsd_decay_steps.
-            # Bound it so both the stable and decay phases are non-degenerate: 0-length phases
-            # give SequentialLR a zero T_max/total_iters (ZeroDivisionError) or non-increasing
-            # milestones (silently wrong LR).
-            if not 0 < cfg.wsd_decay_steps < post_steps:
-                raise ValueError(
-                    f"WSD needs 0 < wsd_decay_steps < max_steps - warmup_steps; got "
-                    f"wsd_decay_steps={cfg.wsd_decay_steps}, warmup_steps={warmup_steps}, "
-                    f"max_steps={max_steps}"
-                )
-            stable_steps = post_steps - cfg.wsd_decay_steps
-            phases.append(LinearLR(ctx.optimizer, 1.0, 1.0, stable_steps))
-            match cfg.wsd_decay_type:
-                case "linear":
-                    phases.append(
-                        LinearLR(ctx.optimizer, 1.0, min_lr / max_lr, cfg.wsd_decay_steps)
+
+    def build(optimizer: Optimizer) -> LRScheduler:
+        # Linear warmup min_lr -> max_lr. Skipped when warmup_steps == 0: a
+        # zero-length LinearLR is degenerate and pins the next phase at min_lr.
+        phases, milestones = [], []
+        if warmup_steps > 0:
+            phases.append(LinearLR(optimizer, min_lr / max_lr, 1.0, warmup_steps))
+            milestones.append(warmup_steps)
+        match cfg.scheduler:
+            case "CosineAnnealing":
+                phases.append(CosineAnnealingLR(optimizer, post_steps, min_lr))
+            case "Constant":
+                phases.append(LinearLR(optimizer, 1.0, 1.0, post_steps))
+            case "WSD":
+                # warmup -> stable (hold max_lr) -> decay (to min_lr) over
+                # wsd_decay_steps. Bound it so the stable and decay phases are both
+                # non-degenerate (a 0-length phase gives SequentialLR a zero T_max
+                # or non-increasing milestones).
+                if not 0 < cfg.wsd_decay_steps < post_steps:
+                    raise ValueError(
+                        f"WSD needs 0 < wsd_decay_steps < max_steps - warmup_steps; got "
+                        f"wsd_decay_steps={cfg.wsd_decay_steps}, warmup_steps={warmup_steps}, "
+                        f"max_steps={max_steps}"
                     )
-                case "cosine":
-                    phases.append(CosineAnnealingLR(ctx.optimizer, cfg.wsd_decay_steps, min_lr))
-                case _:
-                    raise ValueError(f"Unknown wsd_decay_type: {cfg.wsd_decay_type!r}")
-            milestones.append(warmup_steps + stable_steps)
-        case _:
-            raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")
-    ctx.scheduler = SequentialLR(ctx.optimizer, phases, milestones)
+                stable_steps = post_steps - cfg.wsd_decay_steps
+                phases.append(LinearLR(optimizer, 1.0, 1.0, stable_steps))
+                match cfg.wsd_decay_type:
+                    case "linear":
+                        phases.append(
+                            LinearLR(optimizer, 1.0, min_lr / max_lr, cfg.wsd_decay_steps)
+                        )
+                    case "cosine":
+                        phases.append(CosineAnnealingLR(optimizer, cfg.wsd_decay_steps, min_lr))
+                    case _:
+                        raise ValueError(f"Unknown wsd_decay_type: {cfg.wsd_decay_type!r}")
+                milestones.append(warmup_steps + stable_steps)
+            case _:
+                raise ValueError(f"Unknown scheduler: {cfg.scheduler!r}")
+        return SequentialLR(optimizer, phases, milestones)
+
+    # One scheduler per optimizer, identical shape -> same LR curve for all.
+    ctx.schedulers = tuple(build(opt) for opt in ctx.optimizers)
 
 
 @contextmanager

--- a/pithtrain/tasks/pretrain_lm.py
+++ b/pithtrain/tasks/pretrain_lm.py
@@ -187,13 +187,13 @@ class AppState(Stateful):
     def __init__(
         self,
         model: nn.Module,
-        optimizer: Optimizer,
-        scheduler: LRScheduler,
+        optimizers: tuple[Optimizer, ...],
+        schedulers: tuple[LRScheduler, ...],
         model_only: bool = False,
     ):
         self.model = model
-        self.optimizer = optimizer
-        self.scheduler = scheduler
+        self.optimizers = optimizers
+        self.schedulers = schedulers
         self.model_only = model_only
 
     def state_dict(self):
@@ -210,12 +210,12 @@ class AppState(Stateful):
         advertised so DCP's planner does not look for missing optimizer keys.
         """
         if self.model_only:
-            model_state, _ = get_state_dict(self.model, self.optimizer)
+            model_state, _ = get_state_dict(self.model, self.optimizers)
             return {"model": to_canonical_model(model_state, self.model)}
-        model_state, optim_state = get_state_dict(self.model, self.optimizer)
+        model_state, optim_state = get_state_dict(self.model, self.optimizers)
         model_state = to_canonical_model(model_state, self.model)
         optim_state = to_canonical_optim(optim_state, self.model)
-        sched_state = self.scheduler.state_dict()
+        sched_state = [s.state_dict() for s in self.schedulers]
         return {"model": model_state, "optimizer": optim_state, "scheduler": sched_state}
 
     def load_state_dict(self, state_dict):
@@ -235,20 +235,23 @@ class AppState(Stateful):
         sched_state = state_dict.get("scheduler")
 
         if optim_state:
-            optim_state = to_localized_optim(optim_state, self.model)
+            optim_state = to_localized_optim(optim_state, self.model, self.optimizers)
             kwargs = dict(model_state_dict=model_state, optim_state_dict=optim_state)
-            set_state_dict(self.model, self.optimizer, **kwargs)
+            set_state_dict(self.model, self.optimizers, **kwargs)
         else:
             options = StateDictOptions(strict=False)
             set_model_state_dict(self.model, model_state, options=options)
         if sched_state:
-            if _scheduler_structure_mismatch(sched_state, self.scheduler):
-                raise ValueError(
-                    "Checkpoint scheduler structure does not match the current config; "
-                    "resuming across a scheduler/warmup/decay change is not supported. "
-                    "Resume with the same scheduler config, or train from scratch."
-                )
-            self.scheduler.load_state_dict(sched_state)
+            if isinstance(sched_state, dict):  # legacy single-scheduler ckpt
+                sched_state = [sched_state]
+            for scheduler, st in zip(self.schedulers, sched_state):
+                if _scheduler_structure_mismatch(st, scheduler):
+                    raise ValueError(
+                        "Checkpoint scheduler structure does not match the current config; "
+                        "resuming across a scheduler/warmup/decay change is not supported. "
+                        "Resume with the same scheduler config, or train from scratch."
+                    )
+                scheduler.load_state_dict(st)
 
 
 def raise_if_dataset_insufficient(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
@@ -294,16 +297,16 @@ def save_checkpoint(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
     assert cfg.training.save_location is not None
     save_location = Path(cfg.training.save_location, "torch-dcp", "step-%08d" % ctx.training.step)
     model = ctx.training.model
-    optimizer = ctx.training.optimizer
-    scheduler = ctx.training.scheduler
+    optimizers = ctx.training.optimizers
+    schedulers = ctx.training.schedulers
 
     options = StateDictOptions(cpu_offload=True)
-    model_state, optim_state = get_state_dict(model, optimizer, options=options)
+    model_state, optim_state = get_state_dict(model, optimizers, options=options)
     state_dict = dict()
     state_dict["app"] = dict()
     state_dict["app"]["model"] = to_canonical_model(model_state, model)
     state_dict["app"]["optimizer"] = to_canonical_optim(optim_state, model)
-    state_dict["app"]["scheduler"] = scheduler.state_dict()
+    state_dict["app"]["scheduler"] = [s.state_dict() for s in schedulers]
 
     stdout.info("Save checkpoint: %s" % save_location)
     t0 = time.monotonic()
@@ -338,8 +341,9 @@ def load_checkpoint(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
     torch.cuda.empty_cache()
     metadata = FileSystemReader(str(load_location)).read_metadata()
     model_only = all(k.startswith("app.model.") for k in metadata.state_dict_metadata)
-    model, optimizer, scheduler = ctx.training.model, ctx.training.optimizer, ctx.training.scheduler
-    app_state = AppState(model, optimizer, scheduler, model_only=model_only)
+    model = ctx.training.model
+    optimizers, schedulers = ctx.training.optimizers, ctx.training.schedulers
+    app_state = AppState(model, optimizers, schedulers, model_only=model_only)
     dcp.load({"app": app_state}, checkpoint_id=load_location)
     rank = torch.distributed.get_rank()
     rng_path = Path(load_location, "rng-rank-%05d.pt" % rank)
@@ -380,8 +384,8 @@ def train_step(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
     torch.cuda.memory.reset_peak_memory_stats()
 
     model = ctx.training.model
-    optimizer = ctx.training.optimizer
-    scheduler = ctx.training.scheduler
+    optimizers = ctx.training.optimizers
+    schedulers = ctx.training.schedulers
     model.train()
 
     dp_size = ctx.distributed.dp_size
@@ -420,10 +424,13 @@ def train_step(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
     # Clip the gradients.
     gradient_norm = clip_grad_norm_(model, max_norm=1.0, norm_type=2)
 
-    # Take an optimization step.
-    optimizer.step()
-    scheduler.step()
-    optimizer.zero_grad(set_to_none=True)
+    # Take an optimization step (composed optimizers + their schedulers).
+    for optimizer in optimizers:
+        optimizer.step()
+    for scheduler in schedulers:
+        scheduler.step()
+    for optimizer in optimizers:
+        optimizer.zero_grad(set_to_none=True)
     MoELoadBalanceLossTracker.reset()
 
     # Measure the elapsed time in seconds.
@@ -455,7 +462,7 @@ def train_step(cfg: PretrainLMCfg, ctx: PretrainLMCtx) -> None:
     if ctx.distributed.rank == 0:
         step = ctx.training.step
         max_steps = cfg.training.max_steps
-        loss, lr = torch.mean(loss).item(), scheduler.get_last_lr()[0]
+        loss, lr = torch.mean(loss).item(), schedulers[0].get_last_lr()[0]
         tokens_per_second = global_batch_size * cfg.training.sequence_length / elapsed
         statements = []
         statements.append("step %08d/%08d" % (step + 1, max_steps))

--- a/tests/test_muon.py
+++ b/tests/test_muon.py
@@ -1,0 +1,222 @@
+"""CPU tests for the Muon optimizer (``pithtrain.modules.optimizer``) and its
+checkpoint wiring. The FSDP gather/reshard path is in the multi-GPU tests."""
+
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+
+from pithtrain.modules.checkpoint import to_canonical_optim, to_localized_optim
+from pithtrain.modules.optimizer import (
+    Muon,
+    is_muon_param,
+    muon_scale_factor,
+    partition_muon_params,
+    zeropower_via_newtonschulz5,
+)
+
+# ---------------------------------------------------------------------------
+# Newton-Schulz orthogonalization
+# ---------------------------------------------------------------------------
+
+
+def _well_conditioned(n: int, m: int):
+    """Random (n, m) with singular values in [0.5, 1.5] and its true UV^T.
+
+    NS only drives the spectrum toward ~1 on well-conditioned inputs (a raw
+    Gaussian is near-singular), so we control it to test convergence."""
+    r = min(n, m)
+    u, _ = torch.linalg.qr(torch.randn(n, r))
+    v, _ = torch.linalg.qr(torch.randn(m, r))
+    s = torch.empty(r).uniform_(0.5, 1.5)
+    return (u * s) @ v.mT, u @ v.mT
+
+
+@torch.no_grad()
+def test_newton_schulz_approximates_orthogonalization():
+    torch.manual_seed(0)
+    # Square, tall, and wide: NS must handle the transpose-for-tall trick.
+    for shape in [(64, 64), (96, 48), (48, 96)]:
+        g, true = _well_conditioned(*shape)
+        o = zeropower_via_newtonschulz5(g, steps=5).float()
+
+        # Newton-Schulz drives the singular values toward ~1.
+        svals = torch.linalg.svdvals(o)
+        assert svals.min() > 0.5, (shape, svals.min().item())
+        assert svals.max() < 1.5, (shape, svals.max().item())
+
+        # ... and points the same direction as the true UV^T.
+        cos = torch.nn.functional.cosine_similarity(o.flatten(), true.flatten(), dim=0)
+        assert cos > 0.97, (shape, cos.item())
+
+
+@torch.no_grad()
+def test_newton_schulz_batched_experts():
+    """A stacked [E, out, in] expert weight is orthogonalized per-expert."""
+    torch.manual_seed(0)
+    mats = [_well_conditioned(32, 48) for _ in range(4)]
+    g = torch.stack([m[0] for m in mats])
+    o = zeropower_via_newtonschulz5(g, steps=5).float()
+    assert o.shape == g.shape
+    for e, (_, true) in enumerate(mats):
+        cos = torch.nn.functional.cosine_similarity(o[e].flatten(), true.flatten(), dim=0)
+        assert cos > 0.97, (e, cos.item())
+
+
+def test_muon_scale_factor():
+    assert muon_scale_factor(8, 8) == 0.2 * 8**0.5
+    assert muon_scale_factor(100, 4) == 0.2 * 100**0.5  # uses max dim
+    assert muon_scale_factor(4, 100) == 0.2 * 100**0.5
+
+
+# ---------------------------------------------------------------------------
+# Parameter classification
+# ---------------------------------------------------------------------------
+
+
+def test_is_muon_param_classification():
+    # (name, ndim, expected) covering every param kind across the 3 models.
+    cases = [
+        # 2D attention / MLP / MLA hidden weights -> Muon
+        ("model.layers.0.self_attn.q_proj.weight", 2, True),
+        ("model.layers.0.self_attn.k_proj.weight", 2, True),
+        ("model.layers.0.self_attn.o_proj.weight", 2, True),
+        ("model.layers.0.self_attn.kv_a_proj_with_mqa.weight", 2, True),
+        ("model.layers.0.self_attn.kv_b_proj.weight", 2, True),
+        ("model.layers.0.mlp.gate_proj.weight", 2, True),
+        ("model.layers.0.mlp.up_proj.weight", 2, True),
+        ("model.layers.0.mlp.down_proj.weight", 2, True),
+        # 3D stacked expert weights (incl. fused gate_up) -> Muon
+        ("model.layers.0.mlp.experts.gate_proj.weight", 3, True),
+        ("model.layers.0.mlp.experts.down_proj.weight", 3, True),
+        ("model.layers.0.mlp.experts.gate_up_proj.weight", 3, True),
+        # biases (1D and 2D-stacked) -> aux
+        ("model.layers.0.self_attn.q_proj.bias", 1, False),
+        ("model.layers.0.mlp.experts.gate_up_proj_bias", 2, False),
+        ("model.layers.0.mlp.experts.down_proj_bias", 2, False),
+        # norms / sinks (1D) -> aux
+        ("model.layers.0.input_layernorm.weight", 1, False),
+        ("model.layers.0.self_attn.q_norm.weight", 1, False),
+        ("model.layers.0.self_attn.kv_a_layernorm.weight", 1, False),
+        ("model.layers.0.self_attn.sinks", 1, False),
+        # router / gate (2D but a classifier) -> aux
+        ("model.layers.0.mlp.gate.weight", 2, False),
+        ("model.layers.0.mlp.router.weight", 2, False),
+        ("model.layers.0.mlp.router.bias", 1, False),
+        # embeddings / head (2D) -> aux
+        ("model.embed_tokens.weight", 2, False),
+        ("model.lm_head.weight", 2, False),
+    ]
+    for name, ndim, expected in cases:
+        param = torch.empty([4] * ndim)
+        assert is_muon_param(name, param) is expected, name
+
+
+class _TinyModel(nn.Module):
+    """Minimal module whose named parameters span both optimizer groups."""
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(8, 8, bias=True)  # weight -> Muon, bias -> aux
+        self.o_proj = nn.Linear(8, 8, bias=False)  # weight -> Muon
+        self.norm = nn.LayerNorm(8)  # weight + bias (1D) -> aux
+        self.embed_tokens = nn.Embedding(16, 8)  # 2D, name-excluded -> aux
+
+
+def test_partition_muon_params():
+    model = _TinyModel()
+    muon_params, aux_params = partition_muon_params(model)
+
+    muon_ids = {id(p) for p in muon_params}
+    aux_ids = {id(p) for p in aux_params}
+    all_ids = {id(p) for p in model.parameters() if p.requires_grad}
+
+    assert muon_ids.isdisjoint(aux_ids)  # exactly one group each
+    assert muon_ids | aux_ids == all_ids  # full coverage
+    assert muon_ids == {id(model.q_proj.weight), id(model.o_proj.weight)}
+
+
+# ---------------------------------------------------------------------------
+# Optimizer step math (plain tensors)
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def test_muon_step_matches_manual_update():
+    torch.manual_seed(0)
+    lr, beta, wd = 0.02, 0.9, 0.1
+    p = nn.Parameter(torch.randn(16, 24))
+    p.grad = torch.randn(16, 24)
+    p0, grad = p.detach().clone(), p.grad.clone()
+
+    Muon([p], lr=lr, momentum=beta, weight_decay=wd).step()
+
+    buf = (1 - beta) * grad
+    update = grad.lerp(buf, beta)
+    orth = zeropower_via_newtonschulz5(update, steps=5).to(p.dtype)
+    orth = orth * muon_scale_factor(update.size(-2), update.size(-1))
+    expected = p0 * (1 - lr * wd) - lr * orth
+    torch.testing.assert_close(p.detach(), expected, rtol=1e-5, atol=1e-5)
+
+
+@torch.no_grad()
+def test_step_accepts_bf16_grad():
+    """bf16 grads must not dtype-clash with Muon's fp32 state."""
+    torch.manual_seed(0)
+    # bf16 params/grads (as under FSDP param_dtype=bf16) vs the fp32 momentum
+    # buffer, composed as in training: Muon for the weight, AdamW for the bias.
+    w = nn.Parameter(torch.randn(16, 24, dtype=torch.bfloat16))  # 2D -> Muon
+    b = nn.Parameter(torch.randn(24, dtype=torch.bfloat16))  # 1D -> aux
+    w.grad = torch.randn(16, 24, dtype=torch.bfloat16)
+    b.grad = torch.randn(24, dtype=torch.bfloat16)
+
+    Muon([w], lr=0.02).step()
+    AdamW([b], lr=3e-4).step()
+    assert torch.isfinite(w).all() and torch.isfinite(b).all()
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint param-group round-trip (no DCP, no experts)
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_param_groups_preserve_membership():
+    """A composed [Muon, AdamW] state dict round-trips: each group keeps its own
+    membership and hyperparameters (no leakage), as DCP does for optimizers."""
+    model = _TinyModel()
+    muon_params, aux_params = partition_muon_params(model)
+    optimizers = (Muon(muon_params, lr=0.01), AdamW(aux_params, lr=0.01, weight_decay=0.0))
+
+    name_of = {p: n for n, p in model.named_parameters()}
+    muon_fqns = [name_of[p] for p in muon_params]
+    aux_fqns = [name_of[p] for p in aux_params]
+
+    # Combined (Muon, AdamW) state dict as DCP returns it: FQN-keyed state,
+    # param_groups in optimizer order.
+    optim_state = {
+        "state": {n: {"momentum_buffer": torch.zeros(1)} for n in muon_fqns}
+        | {
+            n: {"exp_avg": torch.zeros(1), "exp_avg_sq": torch.zeros(1), "step": 1}
+            for n in aux_fqns
+        },
+        "param_groups": [
+            {"params": list(muon_fqns), "lr": 0.01, "momentum": 0.95, "weight_decay": 0.0},
+            {
+                "params": list(aux_fqns),
+                "lr": 0.01,
+                "betas": (0.9, 0.999),
+                "eps": 1e-8,
+                "weight_decay": 0.0,
+                "amsgrad": False,
+            },
+        ],
+    }
+
+    localized = to_localized_optim(to_canonical_optim(optim_state, model), model, optimizers)
+    muon_group, aux_group = localized["param_groups"]
+
+    assert set(muon_group["params"]) == set(muon_fqns)
+    assert set(aux_group["params"]) == set(aux_fqns)
+    assert set(muon_group["params"]).isdisjoint(aux_group["params"])
+    # Per-group hyperparameters stay with the right group (no leakage).
+    assert "momentum" in muon_group and "betas" not in muon_group
+    assert "betas" in aux_group and "momentum" not in aux_group

--- a/tests/test_muon_checkpoint.py
+++ b/tests/test_muon_checkpoint.py
@@ -1,0 +1,192 @@
+"""
+Multi-GPU checkpoint round-trip for the composed Muon + AdamW optimizer.
+
+Run (needs >=2 GPUs; ep-size must divide the world)::
+
+    torchrun --nproc-per-node=8 tests/test_muon_checkpoint.py
+    torchrun --nproc-per-node=8 tests/test_muon_checkpoint.py --model gpt-oss-20b
+
+Builds a real model (``--model``: deepseek-v2-lite, qwen3-30b-a3b, gpt-oss-20b;
+reduced to a few layers) with FSDP2 + DualPipeV, steps the composed
+``[Muon, AdamW]`` on synthetic grads to populate state, then
+save_checkpoint -> fresh optimizers -> load_checkpoint and asserts the optimizer
+state round-trips exactly. Exercises the resharding (``to_canonical_optim`` /
+``to_localized_optim``) for a combined multi-optimizer state dict over stacked
+experts (expanded to per-expert FQNs on disk) and DualPipeV ``module.N.``
+prefixes. No forward pass, so no dataset and no attention kernel needed.
+"""
+
+import argparse
+import json
+import shutil
+import tempfile
+from contextlib import ExitStack
+from pathlib import Path
+
+import torch
+from torch.distributed.tensor import DTensor
+
+from pithtrain.modules.distributed import distributed_context
+from pithtrain.modules.logging import logging_context
+from pithtrain.modules.training import setup_model, setup_optimizer, setup_scheduler
+from pithtrain.tasks.pretrain_lm import (
+    PretrainLMCfg,
+    PretrainLMCtx,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+NUM_LAYERS = 4  # a few MoE layers; small enough to build quickly
+
+MODELS = {
+    "deepseek-v2-lite": "examples/pretrain_lm/deepseek-v2-lite/config.json",  # MLA, GroupLinear experts
+    "qwen3-30b-a3b": "examples/pretrain_lm/qwen3-30b-a3b/config.json",  # GQA + q/k_norm
+    "gpt-oss-20b": "examples/pretrain_lm/gpt-oss-20b/config.json",  # sinks, fused gate_up, expert biases
+}
+
+
+def opt_state_snapshot(optimizers, model):
+    """fqn -> {state_key: cpu fp32 tensor (or scalar)} across all optimizers."""
+    param_to_fqn = {p: n for n, p in model.named_parameters()}
+    snap = {}
+    for opt in optimizers:
+        for group in opt.param_groups:
+            for p in group["params"]:
+                entry = {}
+                for k, v in opt.state.get(p, {}).items():
+                    if isinstance(v, torch.Tensor):
+                        full = v.full_tensor() if isinstance(v, DTensor) else v
+                        entry[k] = full.detach().float().cpu().clone()
+                    else:
+                        entry[k] = v
+                snap[param_to_fqn[p]] = entry
+    return snap
+
+
+def main(cfg: PretrainLMCfg, ctx: PretrainLMCtx):
+    rank = torch.distributed.get_rank()
+
+    def rprint(*a):
+        if rank == 0:
+            print(*a, flush=True)
+
+    model = ctx.training.model
+    optimizers = ctx.training.optimizers
+    n_muon = sum(len(g["params"]) for g in optimizers[0].param_groups)
+    n_aux = sum(len(g["params"]) for g in optimizers[1].param_groups)
+    rprint(f"[INFO] composed optimizers: Muon over {n_muon} params, AdamW over {n_aux} params")
+
+    # Synthetic grads -> step to populate optimizer state (no forward needed).
+    torch.manual_seed(1234 + rank)
+    for p in model.parameters():
+        if p.requires_grad:
+            p.grad = torch.randn_like(p).mul_(0.01)
+    for opt in optimizers:
+        opt.step()
+    # Clear grads so the load-side _init_optim_state materializes the state
+    # template (it skips if any grad is set) -- as in the real resume flow.
+    for opt in optimizers:
+        opt.zero_grad(set_to_none=True)
+
+    bad = [
+        n
+        for n, p in model.named_parameters()
+        if not torch.isfinite(p.to_local() if isinstance(p, DTensor) else p).all()
+    ]
+    assert not bad, ("non-finite params after step", bad[:3])
+
+    # Snapshot, save, rebuild fresh optimizers, load, compare.
+    ctx.training.step = 1
+    before = opt_state_snapshot(optimizers, model)
+    save_checkpoint(cfg, ctx)
+
+    setup_optimizer(cfg.training, ctx.training)  # fresh, empty-state optimizers
+    setup_scheduler(cfg.training, ctx.training)
+    load_checkpoint(cfg, ctx)
+    after = opt_state_snapshot(ctx.training.optimizers, model)
+
+    assert set(before) == set(after), "param FQN set changed across the round-trip"
+    max_diff, worst = 0.0, None
+    for n in before:
+        assert set(before[n]) == set(after[n]), (n, set(before[n]), set(after[n]))
+        for k in before[n]:
+            a, b = before[n][k], after[n][k]
+            if isinstance(a, torch.Tensor):
+                diff = (a - b).abs().max().item()
+                if diff > max_diff:
+                    max_diff, worst = diff, (n, k)
+            else:
+                assert a == b, (n, k, a, b)
+
+    muon_fqns = [n for n in before if "momentum_buffer" in before[n]]
+    aux_fqns = [n for n in before if "exp_avg" in before[n]]
+    assert muon_fqns and aux_fqns, "expected both Muon and aux optimizer state"
+    assert max_diff < 1e-3, f"optimizer state mismatch after round-trip: {max_diff}"
+    if rank == 0:
+        print(
+            f"[INFO] optimizer state round-trips: {len(muon_fqns)} Muon (momentum_buffer), "
+            f"{len(aux_fqns)} aux (exp_avg/exp_avg_sq). max|diff|={max_diff:.2e} (worst: {worst})",
+            flush=True,
+        )
+        print("[PASS] test_muon_checkpoint", flush=True)
+
+
+def _entry():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ep-size", type=int, default=2)
+    parser.add_argument("--model", choices=list(MODELS), default="deepseek-v2-lite")
+    parsed = parser.parse_args()
+
+    cfg = PretrainLMCfg()
+    cfg.distributed.pipeline_parallel_size = 1
+    cfg.distributed.context_parallel_size = 1
+    cfg.distributed.expert_parallel_size = parsed.ep_size
+    t = cfg.training
+    t.optimizer = "Muon"
+    t.scheduler = "CosineAnnealing"
+    t.max_lr = 4.2e-4
+    t.min_lr = 1.0e-5
+    t.warmup_steps = 8
+    t.max_steps = 40
+    t.micro_batch_size = 1
+    t.global_batch_size = 64
+    t.sequence_length = 2048
+    t.moe_load_balance_type = "sequence"
+    t.moe_load_balance_coef = 3e-3
+    t.fp8_training = "disabled"
+
+    ctx = PretrainLMCtx()
+    with ExitStack() as stack:
+        stack.enter_context(logging_context(cfg, ctx))
+        stack.enter_context(distributed_context(cfg, ctx))
+
+        # Reduced config + checkpoint dir on local scratch (rank 0 writes).
+        scratch = Path(tempfile.gettempdir(), "pithtrain_test_muon_checkpoint")
+        if torch.distributed.get_rank() == 0:
+            print(
+                f"[INFO] model={parsed.model}, ep={parsed.ep_size}, layers={NUM_LAYERS}", flush=True
+            )
+            shutil.rmtree(scratch, ignore_errors=True)
+            scratch.mkdir(parents=True)
+            src = Path(__file__).resolve().parent.parent / MODELS[parsed.model]
+            config = json.loads(src.read_text())
+            config["num_hidden_layers"] = NUM_LAYERS
+            if "layer_types" in config:  # gpt-oss alternates sliding/full attention per layer
+                config["layer_types"] = config["layer_types"][:NUM_LAYERS]
+            (scratch / "config.json").write_text(json.dumps(config))
+        torch.distributed.barrier()
+        t.model = scratch / "config.json"
+        t.dataset = scratch  # unused; set to satisfy the config
+        t.save_location = scratch / "checkpoint"
+
+        # Build model + optimizers + schedulers directly (no dataset needed).
+        ctx.training.step = 0
+        torch.manual_seed(0)
+        setup_model(cfg.training, ctx.training, cfg.distributed, ctx.distributed)
+        setup_optimizer(cfg.training, ctx.training)
+        setup_scheduler(cfg.training, ctx.training)
+        main(cfg, ctx)
+
+
+if __name__ == "__main__":
+    _entry()

--- a/tests/test_muon_fp8.py
+++ b/tests/test_muon_fp8.py
@@ -1,0 +1,46 @@
+"""Smoke test: Muon steps cleanly on gradients from the DeepGEMM FP8 path.
+
+FP8 quantizes only the forward matmuls; grads are bf16/fp32 and the Muon math is
+unchanged. Confirms a real fp8 forward/backward feeds finite grads into a Muon
+step. Requires CUDA + ``deep_gemm`` (skips otherwise)."""
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+
+from pithtrain.modules.optimizer import Muon, partition_muon_params
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+
+@requires_cuda
+def test_muon_step_on_fp8_gradients():
+    pytest.importorskip("deep_gemm")
+    from pithtrain.layers.factory import ModelImplMode, get_linear_cls
+
+    prev = ModelImplMode.fp8_training
+    ModelImplMode.fp8_training = "deep-gemm"
+    try:
+        torch.manual_seed(0)
+        linear_cls = get_linear_cls()
+        # Dims are multiples of 128 for DeepGEMM block scaling.
+        net = nn.Sequential(
+            linear_cls(256, 512, bias=False),
+            linear_cls(512, 256, bias=False),
+        ).to(device="cuda", dtype=torch.bfloat16)
+
+        x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+        net(x).float().pow(2).mean().backward()
+        assert all(p.grad is not None and torch.isfinite(p.grad).all() for p in net.parameters())
+
+        muon_params, aux_params = partition_muon_params(net)
+        optimizers = [Muon(muon_params, lr=0.02)]
+        if aux_params:
+            optimizers.append(AdamW(aux_params, lr=0.02, weight_decay=0.0))
+        for opt in optimizers:
+            opt.step()
+        for name, p in net.named_parameters():
+            assert torch.isfinite(p).all(), name
+    finally:
+        ModelImplMode.fp8_training = prev

--- a/tests/test_muon_fsdp.py
+++ b/tests/test_muon_fsdp.py
@@ -1,0 +1,146 @@
+"""
+Multi-GPU correctness for Muon's distributed Newton-Schulz.
+
+Run (pure DP)::
+
+    torchrun --nproc-per-node=2 tests/test_muon_fsdp.py
+    torchrun --nproc-per-node=8 tests/test_muon_fsdp.py
+
+Run (expert-parallel; experts and dense weights land on different meshes)::
+
+    torchrun --nproc-per-node=8 tests/test_muon_fsdp.py --ep-size 2
+
+Mirrors ``apply_fsdp``: experts shard on the ``(dp, cp)`` mesh, everything else
+on the flattened ``(dp, cp, ep)`` mesh. Injects identical grads into (a) an
+unsharded reference holding this EP rank's slice and (b) the FSDP-sharded model,
+steps both with ``[Muon, AdamW]``, and asserts the sharded update matches the
+reference. fp32 params, so any mismatch is plumbing, not bf16 NS noise (the
+gathered matrix -- hence the NS -- is identical on both sides).
+"""
+
+import argparse
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor, Replicate
+from torch.optim import AdamW
+
+from pithtrain.layers.group_linear import GroupLinear
+from pithtrain.modules.distributed import DistributedCfg, DistributedCtx, distributed_context
+from pithtrain.modules.optimizer import Muon, partition_muon_params
+
+NUM_EXPERTS = 8  # divisible by the EP sizes we test (1, 2, 4)
+
+
+def step_composed(model, lr):
+    """Step the composed optimizers as training does: Muon for hidden weights,
+    AdamW for the rest (separable, so it works element-wise on each shard)."""
+    muon_params, aux_params = partition_muon_params(model)
+    Muon(muon_params, lr=lr).step()
+    if aux_params:
+        AdamW(aux_params, lr=lr, weight_decay=0.0).step()
+
+
+class _Model(nn.Module):
+    """Spans both optimizer groups and both mesh shapes (2D weight, 3D experts,
+    1D/2D Adam)."""
+
+    def __init__(self, num_experts: int):
+        super().__init__()
+        self.q_proj = nn.Linear(64, 48, bias=False)  # 2D -> Muon
+        self.experts = GroupLinear(num_experts, 64, 32)  # 3D experts -> Muon
+        self.norm = nn.LayerNorm(64)  # 1D weight + bias -> Adam
+        self.embed_tokens = nn.Embedding(100, 64)  # 2D, name-excluded -> Adam
+        # GroupLinear uses torch.empty (the framework fills it via init_weights
+        # before FSDP); init it here so the optimizer steps real values, not
+        # uninitialized memory (differs per rank, would break the comparison).
+        nn.init.normal_(self.experts.weight, std=0.02)
+
+
+def main(ctx: DistributedCtx):
+    mesh = ctx.device_mesh
+    ep_size, ep_rank = ctx.ep_size, ctx.ep_rank
+    # Same split as training.apply_fsdp: experts on (dp, cp), the rest on the
+    # flattened (dp, cp, ep) mesh. At ep=cp=1 both collapse to pure dp.
+    moe_mesh = mesh["dp", "cp"]._flatten()
+    other_mesh = mesh["dp", "cp", "ep"]._flatten()
+    device = torch.device("cuda", ctx.local_rank)
+    lr = 0.1
+
+    # Full weights + grads, identical on every rank (same seed).
+    torch.manual_seed(0)
+    full = _Model(NUM_EXPERTS).to(device=device, dtype=torch.float32)
+    full_state = {n: p.detach().clone() for n, p in full.named_parameters()}
+    torch.manual_seed(123)
+    full_grads = {n: torch.randn_like(p) for n, p in full.named_parameters()}
+
+    # This EP rank owns experts[lo:hi]; dense weights are replicated across EP.
+    k = NUM_EXPERTS // ep_size
+    lo, hi = ep_rank * k, (ep_rank + 1) * k
+
+    def ep_slice(name, t):
+        return t[lo:hi] if name == "experts.weight" else t
+
+    # Reference: unsharded model with this EP rank's slice, stepped with Muon.
+    ref = _Model(k).to(device=device, dtype=torch.float32)
+    with torch.no_grad():
+        for n, p in ref.named_parameters():
+            p.copy_(ep_slice(n, full_state[n]))
+    for n, p in ref.named_parameters():
+        p.grad = ep_slice(n, full_grads[n]).clone()
+    step_composed(ref, lr)
+    ref_after = {n: p.detach().clone() for n, p in ref.named_parameters()}
+
+    # FSDP-sharded model: same slice + grads, sharded on the two meshes.
+    shd = _Model(k).to(device=device, dtype=torch.float32)
+    with torch.no_grad():
+        for n, p in shd.named_parameters():
+            p.copy_(ep_slice(n, full_state[n]))
+    fully_shard(shd.experts, mesh=moe_mesh)
+    fully_shard(shd.q_proj, mesh=other_mesh)
+    fully_shard(shd.norm, mesh=other_mesh)
+    fully_shard(shd.embed_tokens, mesh=other_mesh)
+    fully_shard(shd, mesh=other_mesh)
+
+    for n, p in shd.named_parameters():
+        g = ep_slice(n, full_grads[n])
+        g_full = DTensor.from_local(
+            g, p.device_mesh, [Replicate()] * p.device_mesh.ndim, run_check=False
+        )
+        p.grad = g_full.redistribute(placements=p.placements)
+    step_composed(shd, lr)
+
+    max_diff, worst = 0.0, None
+    for n, p in shd.named_parameters():
+        full_p = p.full_tensor() if isinstance(p, DTensor) else p
+        diff = (full_p - ref_after[n]).abs().max().item()
+        if diff > max_diff:
+            max_diff, worst = diff, n
+        assert torch.allclose(full_p, ref_after[n], atol=1e-3, rtol=1e-3), (n, diff)
+
+    if ctx.rank == 0:
+        print(
+            f"[INFO] Muon FSDP step matches single-process reference "
+            f"(dp={ctx.dp_size} cp={ctx.cp_size} ep={ep_size}). "
+            f"max|diff|={max_diff:.2e} (worst param: {worst})",
+            flush=True,
+        )
+        print("[PASS] test_muon_fsdp", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ep-size", type=int, default=1)
+    parser.add_argument("--cp-size", type=int, default=1)
+    parsed = parser.parse_args()
+
+    cfg, ctx = SimpleNamespace(), SimpleNamespace()
+    cfg.distributed = DistributedCfg()
+    cfg.distributed.pipeline_parallel_size = 1
+    cfg.distributed.expert_parallel_size = parsed.ep_size
+    cfg.distributed.context_parallel_size = parsed.cp_size
+    ctx.distributed = DistributedCtx()
+    with distributed_context(cfg, ctx):
+        main(ctx.distributed)


### PR DESCRIPTION
Muon applies a 5-step Newton-Schulz orthogonalization to the SGD-momentum update of each 2D hidden weight; embeddings, the LM head, norms, biases, and the MoE router are optimized by a built-in AdamW. The two are composed as a list and stepped, scheduled, and checkpointed together (optimizer="Muon"), sharing one learning rate via Moonlight's 0.2*sqrt(max(n, m)) update scale.

Under FSDP2 a weight is a sharded DTensor and Newton-Schulz needs the full matrix, so the orthogonalization is parameter-parallel: the weights are round-robined across each one's FSDP mesh, each rank orthogonalizes only ~1/G of them, and the results are broadcast (one collective per owner). The update is bit-identical to running it redundantly on every rank and gets faster as the FSDP group size grows. The composed optimizer's combined state dict reshards across PP/EP with per-group membership and stacked experts expanded on disk.

Correctness was validated on a single 8xH100 node: the Muon step matches a single-process reference (max|diff|=0) across dp/ep/cp meshes, and the checkpoint round-trip is exact for deepseek-v2-lite, qwen3-30b-a3b, and gpt-oss-20b.

## Adam vs Muon (full 16B DeepSeek-V2-Lite, ep=8, global_batch=256, 50 steps)

Same data and init for both; LR=4.2e-4.

| metric | Adam | Muon |
| --- | --- | --- |
| loss @ step 10 / 25 / 50 | 9.79 / 7.40 / 7.28 | 7.75 / 6.19 / 6.07 | | step time (steady state) | 6.87 s | 6.09 s |
| peak GPU memory | 57.2 GB | 47.9 GB |

Muon trains at least as fast in early steps while using ~16% less peak memory and ~11% less step time (one fp32 momentum buffer vs Adam's two moment buffers).

## EP invariance (Muon, 8-layer model, same data/seed/LR, loss per step)

| step | ep=8 | ep=4 | ep=2 |
| --- | --- | --- | --- |
| 1 | 11.974 | 11.915 | 11.952 |
| 8 | 9.605 | 9.659 | 9.643 |
| 15 | 6.762 | 6.720 | 6.764 |
| 20 | 6.610 | 6.583 | 6.588 |

The curves match to within bf16 reduction-order noise (max divergence ~7e-2, non-systematic), confirming experts_per_rank does not affect the result.