### PR TITLE
Remove hardcoded HuggingFace env vars from benchmark scripts

### DIFF
--- a/benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/launch.sh
+++ b/benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/launch.sh
@@ -5,8 +5,6 @@
 export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PWD/benchmarks/pretraining/deepseek-v2-lite
-export HF_HOME=$PWD/workspace/hf-home
-export HF_TOKEN_PATH=$HOME/.cache/huggingface/token
 
 SRUN_ARGS=()
 SRUN_ARGS+=(--nodes=1 --gpus-per-node=8)

--- a/benchmarks/pretraining/gpt-oss-120b/h100-8n8g/launch.sh
+++ b/benchmarks/pretraining/gpt-oss-120b/h100-8n8g/launch.sh
@@ -5,8 +5,6 @@
 export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PWD/benchmarks/pretraining/gpt-oss-120b
-export HF_HOME=$PWD/workspace/hf-home
-export HF_TOKEN_PATH=$HOME/.cache/huggingface/token
 
 SRUN_ARGS=()
 SRUN_ARGS+=(--nodes=8 --gpus-per-node=8)

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/launch.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/launch.sh
@@ -5,8 +5,6 @@
 export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PWD/benchmarks/pretraining/qwen3-30b-a3b
-export HF_HOME=$PWD/workspace/hf-home
-export HF_TOKEN_PATH=$HOME/.cache/huggingface/token
 
 SRUN_ARGS=()
 SRUN_ARGS+=(--nodes=2 --gpus-per-node=8)

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/launch.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/launch.sh
@@ -5,8 +5,6 @@
 export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PWD/benchmarks/pretraining/qwen3-30b-a3b
-export HF_HOME=$PWD/workspace/hf-home
-export HF_TOKEN_PATH=$HOME/.cache/huggingface/token
 
 SRUN_ARGS=()
 SRUN_ARGS+=(--nodes=4 --gpus-per-node=8)

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/launch.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/launch.sh
@@ -5,8 +5,6 @@
 export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PWD/benchmarks/pretraining/qwen3-30b-a3b
-export HF_HOME=$PWD/workspace/hf-home
-export HF_TOKEN_PATH=$HOME/.cache/huggingface/token
 
 SRUN_ARGS=()
 SRUN_ARGS+=(--nodes=8 --gpus-per-node=8)


### PR DESCRIPTION
HF home/token/cache are the user's environment to configure, not ours to override. This drops the hardcoded `HF_HOME` and `HF_TOKEN_PATH` exports from the benchmark launch scripts, bringing them in line with `examples/`.