### PR TITLE
Add MoE router-replay hook for force-balanced benchmarking and RL replay

### DIFF
--- a/benchmarks/pretraining/deepseek-v2-lite/setup.py
+++ b/benchmarks/pretraining/deepseek-v2-lite/setup.py
@@ -1,32 +1,22 @@
 #!/usr/bin/env python3
 """
-Prepare the model checkpoint and the pretraining dataset.
+Prepare the tokenizer and the pretraining dataset.
 """
 
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
 
-from pithtrain.tasks import convert_checkpoint, tokenize_corpus
-from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg
+from pithtrain.tasks import tokenize_corpus
 from pithtrain.tasks.tokenize_corpus import TokenizeCorpusCfg
 
 if __name__ == "__main__":
     Path("workspace").resolve().mkdir(parents=True, exist_ok=True)
 
 if __name__ == "__main__":
-    kwargs = dict()
-    kwargs["repo_id"] = "deepseek-ai/DeepSeek-V2-Lite"
-    kwargs["local_dir"] = "workspace/checkpoints/deepseek-v2-lite/hf-import"
-    snapshot_download(**kwargs, repo_type="model")
-
-if __name__ == "__main__":
-    cfg = ConvertCheckpointCfg()
-    cfg.operation = "hf2dcp"
-    cfg.load_path = Path("workspace/checkpoints/deepseek-v2-lite/hf-import")
-    cfg.save_path = Path("workspace/checkpoints/deepseek-v2-lite/torch-dcp/step-00000000")
-    if not Path(cfg.save_path, ".metadata").exists():
-        convert_checkpoint.launch(cfg)
+    tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-V2-Lite")
+    tokenizer.save_pretrained("workspace/checkpoints/deepseek-v2-lite/hf-import")
 
 if __name__ == "__main__":
     kwargs = dict()
@@ -59,4 +49,4 @@ training.max_steps = 25
 training.dataset = Path("workspace/datasets/dclm-baseline/toktxt/deepseek-v2")
 training.moe_load_balance_type = "global-batch"
 training.moe_load_balance_coef = 1e-3
-training.save_location = Path("workspace/checkpoints/deepseek-v2-lite")
+training.benchmark = True

--- a/benchmarks/pretraining/gpt-oss-120b/setup.py
+++ b/benchmarks/pretraining/gpt-oss-120b/setup.py
@@ -1,32 +1,22 @@
 #!/usr/bin/env python3
 """
-Prepare the model checkpoint and the pretraining dataset.
+Prepare the tokenizer and the pretraining dataset.
 """
 
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
 
-from pithtrain.tasks import convert_checkpoint, tokenize_corpus
-from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg
+from pithtrain.tasks import tokenize_corpus
 from pithtrain.tasks.tokenize_corpus import TokenizeCorpusCfg
 
 if __name__ == "__main__":
     Path("workspace").resolve().mkdir(parents=True, exist_ok=True)
 
 if __name__ == "__main__":
-    kwargs = dict()
-    kwargs["repo_id"] = "openai/gpt-oss-120b"
-    kwargs["local_dir"] = "workspace/checkpoints/gpt-oss-120b/hf-import"
-    snapshot_download(**kwargs, repo_type="model")
-
-if __name__ == "__main__":
-    cfg = ConvertCheckpointCfg()
-    cfg.operation = "hf2dcp"
-    cfg.load_path = Path("workspace/checkpoints/gpt-oss-120b/hf-import")
-    cfg.save_path = Path("workspace/checkpoints/gpt-oss-120b/torch-dcp/step-00000000")
-    if not Path(cfg.save_path, ".metadata").exists():
-        convert_checkpoint.launch(cfg)
+    tokenizer = AutoTokenizer.from_pretrained("openai/gpt-oss-120b")
+    tokenizer.save_pretrained("workspace/checkpoints/gpt-oss-120b/hf-import")
 
 if __name__ == "__main__":
     kwargs = dict()
@@ -59,4 +49,4 @@ training.max_steps = 25
 training.dataset = Path("workspace/datasets/dclm-baseline/toktxt/gpt-oss")
 training.moe_load_balance_type = "micro-batch"
 training.moe_load_balance_coef = 1e-3
-training.save_location = Path("workspace/checkpoints/gpt-oss-120b")
+training.benchmark = True

--- a/benchmarks/pretraining/qwen3-30b-a3b/setup.py
+++ b/benchmarks/pretraining/qwen3-30b-a3b/setup.py
@@ -1,32 +1,22 @@
 #!/usr/bin/env python3
 """
-Prepare the model checkpoint and the pretraining dataset.
+Prepare the tokenizer and the pretraining dataset.
 """
 
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
 
-from pithtrain.tasks import convert_checkpoint, tokenize_corpus
-from pithtrain.tasks.convert_checkpoint import ConvertCheckpointCfg
+from pithtrain.tasks import tokenize_corpus
 from pithtrain.tasks.tokenize_corpus import TokenizeCorpusCfg
 
 if __name__ == "__main__":
     Path("workspace").resolve().mkdir(parents=True, exist_ok=True)
 
 if __name__ == "__main__":
-    kwargs = dict()
-    kwargs["repo_id"] = "Qwen/Qwen3-30B-A3B-Base"
-    kwargs["local_dir"] = "workspace/checkpoints/qwen3-30b-a3b/hf-import"
-    snapshot_download(**kwargs, repo_type="model")
-
-if __name__ == "__main__":
-    cfg = ConvertCheckpointCfg()
-    cfg.operation = "hf2dcp"
-    cfg.load_path = Path("workspace/checkpoints/qwen3-30b-a3b/hf-import")
-    cfg.save_path = Path("workspace/checkpoints/qwen3-30b-a3b/torch-dcp/step-00000000")
-    if not Path(cfg.save_path, ".metadata").exists():
-        convert_checkpoint.launch(cfg)
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-30B-A3B-Base")
+    tokenizer.save_pretrained("workspace/checkpoints/qwen3-30b-a3b/hf-import")
 
 if __name__ == "__main__":
     kwargs = dict()
@@ -59,4 +49,4 @@ training.max_steps = 25
 training.dataset = Path("workspace/datasets/dclm-baseline/toktxt/qwen3")
 training.moe_load_balance_type = "global-batch"
 training.moe_load_balance_coef = 1e-3
-training.save_location = Path("workspace/checkpoints/qwen3-30b-a3b")
+training.benchmark = True

--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -241,6 +241,7 @@ class DeepseekV2LiteMoEGate(nn.Module):
         self.num_experts = config.n_routed_experts
         self.routed_scaling_factor = config.routed_scaling_factor
         self.load_balance_loss_fn = None
+        self.router_replay = None
         self.weight = nn.Parameter(
             torch.empty((self.n_routed_experts, config.hidden_size)), requires_grad=True
         )
@@ -262,6 +263,9 @@ class DeepseekV2LiteMoEGate(nn.Module):
         logits = F.linear(hidden_states.type(torch.float32), self.weight.type(torch.float32), None)
         scores = logits.softmax(dim=-1, dtype=torch.float32)
         topk_weight, topk_idx = torch.topk(scores, k=self.top_k, dim=-1, sorted=False)
+        if self.router_replay is not None:
+            topk_idx = self.router_replay(topk_idx)
+            topk_weight = scores.gather(-1, topk_idx)
         topk_weight = topk_weight * self.routed_scaling_factor
 
         if self.training and self.load_balance_loss_fn is not None:

--- a/pithtrain/models/gpt_oss.py
+++ b/pithtrain/models/gpt_oss.py
@@ -271,6 +271,7 @@ class GptOssTopKRouter(nn.Module):
         self.num_experts = num_experts
         self.num_experts_per_tok = num_experts_per_tok
         self.load_balance_loss_fn = None
+        self.router_replay = None
         self.weight = nn.Parameter(torch.empty((num_experts, hidden_size)), requires_grad=True)
         self.bias = nn.Parameter(torch.zeros(num_experts))
 
@@ -284,6 +285,9 @@ class GptOssTopKRouter(nn.Module):
         logits = F.linear(hidden_states, self.weight, self.bias)
 
         topk_logits, topk_idx = torch.topk(logits, k=self.num_experts_per_tok, dim=-1, sorted=True)
+        if self.router_replay is not None:
+            topk_idx = self.router_replay(topk_idx)
+            topk_logits = logits.gather(-1, topk_idx)
         topk_weight = F.softmax(topk_logits, dim=-1, dtype=torch.float32)
 
         if self.training and self.load_balance_loss_fn is not None:

--- a/pithtrain/models/qwen3_moe.py
+++ b/pithtrain/models/qwen3_moe.py
@@ -195,6 +195,7 @@ class Qwen3MoeGate(nn.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.norm_topk_prob = norm_topk_prob
         self.load_balance_loss_fn = None
+        self.router_replay = None
         self.weight = nn.Parameter(torch.empty((num_experts, hidden_size)), requires_grad=True)
 
     @torch.compile(fullgraph=True)
@@ -223,6 +224,9 @@ class Qwen3MoeGate(nn.Module):
         logits = F.linear(hidden_states, self.weight, None)
         scores = logits.softmax(dim=-1, dtype=torch.float32)
         topk_weight, topk_idx = torch.topk(scores, k=self.num_experts_per_tok, dim=-1, sorted=False)
+        if self.router_replay is not None:
+            topk_idx = self.router_replay(topk_idx)
+            topk_weight = scores.gather(-1, topk_idx)
 
         if self.norm_topk_prob:
             topk_weight = topk_weight / topk_weight.sum(dim=-1, keepdim=True)

--- a/pithtrain/modules/load_balance.py
+++ b/pithtrain/modules/load_balance.py
@@ -1,6 +1,6 @@
-"""MoE routing load balance losses."""
+"""Load balancing for MoE routing."""
 
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import torch
 import torch.distributed
@@ -252,3 +252,20 @@ def make_load_balance_loss_fn(
             raise ValueError(f"Unknown moe_load_balance_type: {lb_type!r}")
     MoELoadBalanceLossTracker.register(loss)
     return loss
+
+
+def force_balance(num_experts: int) -> Callable[[torch.Tensor], torch.Tensor]:
+    """
+    Build a benchmark-only router replay that spreads tokens evenly across all
+    ``num_experts`` (round-robin), giving every expert an equal, dropless load.
+    The returned callable rewrites a gate's top-k indices, keeping their shape.
+    """
+
+    def replay(topk_idx: torch.Tensor) -> torch.Tensor:
+        num_tokens, top_k = topk_idx.shape
+        stride = num_experts // top_k
+        t = torch.arange(num_tokens, device=topk_idx.device).unsqueeze(1)
+        j = torch.arange(top_k, device=topk_idx.device).unsqueeze(0)
+        return (t + j * stride) % num_experts
+
+    return replay

--- a/pithtrain/modules/training.py
+++ b/pithtrain/modules/training.py
@@ -26,7 +26,7 @@ from pithtrain.models.deepseek_v2_lite import DeepseekV2LiteModel
 from pithtrain.models.gpt_oss import GptOssModel
 from pithtrain.models.qwen3_moe import Qwen3MoeModel
 from pithtrain.modules.dataset import ConcatDataset, MemmapDataset
-from pithtrain.modules.load_balance import make_load_balance_loss_fn
+from pithtrain.modules.load_balance import force_balance, make_load_balance_loss_fn
 from pithtrain.modules.optimizer import Muon
 
 from .distributed import DistributedCfg, DistributedCtx
@@ -218,6 +218,18 @@ class TrainingCfg(SlottedDefault):
       accumulation steps (https://arxiv.org/abs/2501.11873).
     * "sequence" - Sequence-level loss computed independently per sequence
       then averaged over the batch (https://arxiv.org/abs/2405.04434).
+    """
+
+    benchmark: bool = False
+    """
+    Benchmark mode: enable tuning that makes throughput measurement easy-to-setup and comparable
+    but is wrong for real training. Effects include:
+
+    * Force-balanced MoE routing: every expert gets an equal, dropless token load.
+      This is the convention NeMo Megatron-Bridge uses for its MoE benchmarks
+      (https://docs.nvidia.com/nemo/megatron-bridge/latest/performance-summary.html).
+
+    By default, this flag is False, so normal training is unaffected.
     """
 
     fp8_training: Literal["deep-gemm", "disabled"] = "disabled"
@@ -498,6 +510,12 @@ def setup_model(
                     if hasattr(loss_fn, "init_buffers"):
                         loss_fn.init_buffers(gate.num_experts, gate.weight.device)
                     gate.load_balance_loss_fn = loss_fn
+
+    # Benchmark mode: force-balance every MoE gate's routing.
+    if cfg.benchmark:
+        for module in modules.modules():
+            if hasattr(module, "router_replay"):
+                module.router_replay = force_balance(module.num_experts)
 
     ctx.model = DualPipeV(modules, pp_group=pp_group, ep_group=ep_group)
     set_p2p_tensor_shapes([(micro_batch_size, local_seq_len, hidden_size)])


### PR DESCRIPTION
RL rollout-replay and benchmark force-balancing turn out to want the same thing: override a gate's top-k expert choice from outside while keeping the weights live. So we designed one hook for both.

`gate.router_replay` is an optional callable that replaces a gate's top-k indices; the routing weights are re-gathered from the live scores, so only the discrete choice changes. Two uses of the one interface:

1. **Router replay**: drive routing externally. A future RL trainer replays a rollout's routing so the training forward routes identically (rollout-then-train consistency).

2. **Force-balanced benchmarking**: a new `cfg.training.benchmark` flag plugs in a round-robin replay so every expert gets an equal, dropless load. Same convention as Megatron-Bridge's MoE benchmarks: https://docs.nvidia.com/nemo/megatron-bridge/latest/performance-summary.html

Since routing is forced, benchmarks drop the pretrained checkpoint and fetch only the tokenizer.

### Correctness

As expected from the changes: `load-balance-loss` is pinned at `1.000000` (perfectly balanced routing) and `cross-entropy-loss` is ~12 (untrained, since no checkpoint is loaded with the router being forced-balanced).

```
[rank0] layer_partition: 27 layers / 2 stages -> [14, 13]
[rank0] layer_partition: 27 layers / 2 stages -> [14, 13]
2026-06-23 01:29:38 | INFO | launch(cfg=PretrainLMCfg(distributed=DistributedCfg(pipeline_parallel_size=1, context_parallel_size=1, expert_parallel_size=8, timeout=datetime.timedelta(seconds=900), sharding_strategy='fsdp'), training=TrainingCfg(dataset=PosixPath('workspace/datasets/dclm-baseline/toktxt/deepseek-v2'), sequence_length=2048, seed=1234, lr=1e-06, max_steps=25, micro_batch_size=1, global_batch_size=1024, optimizer=<function make_muon_optimizer at 0xe65109457a0>, scheduler=<function make_constant_scheduler at 0xe6510945bc0>, model=PosixPath('benchmarks/pretraining/deepseek-v2-lite/model.json'), save_interval=None, save_location=None, moe_load_balance_coef=0.001, moe_load_balance_type='global-batch', benchmark=True, fp8_training='disabled', init_std=0.02, nsys_start=None, nsys_stop=None, memory_profile_start=None, memory_profile_stop=None, memory_profile_output=PosixPath('/home/haok/pith-train')), logging=LoggingCfg(wandb=None)))
2026-06-23 01:29:38 | INFO | No save_location set; training from scratch.
2026-06-23 01:30:40 | INFO | step 00000001/00000025 | step-time 62.105 sec | cross-entropy-loss 11.9881 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 35.6103 | tokens-per-second 33,768 | peak-gpu-memory 39.73 GB
2026-06-23 01:31:04 | INFO | step 00000002/00000025 | step-time 23.277 sec | cross-entropy-loss 11.9855 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 39.1347 | tokens-per-second 90,094 | peak-gpu-memory 47.25 GB
2026-06-23 01:31:28 | INFO | step 00000003/00000025 | step-time 23.475 sec | cross-entropy-loss 11.9792 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 35.4346 | tokens-per-second 89,337 | peak-gpu-memory 47.26 GB
2026-06-23 01:31:51 | INFO | step 00000004/00000025 | step-time 22.993 sec | cross-entropy-loss 11.9767 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 34.9587 | tokens-per-second 91,207 | peak-gpu-memory 47.26 GB
2026-06-23 01:32:15 | INFO | step 00000005/00000025 | step-time 23.685 sec | cross-entropy-loss 11.9684 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 33.3818 | tokens-per-second 88,544 | peak-gpu-memory 47.26 GB
```