### PR TITLE
Add Claude Code GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,32 @@
+name: Claude Code Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    environment: review
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          allow-unsafe-pr-checkout: true
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: '*'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
Two workflows that bring Claude review and assistance to this repo, set up to support open-source development where contributors work from forks.

- **`claude.yml`**: interactive `@claude` assistant on issues, PR comments, and reviews. Runs only on `@claude` mentions from write-access users (no approval needed).
- **`claude-code-review.yml`**: automated PR review. Posts findings as inline comments via the `code-review` plugin.

Workarounds for fork-based contributions:

- Uses `pull_request_target` (not `pull_request`) so reviews on fork PRs can reach secrets. GitHub withholds secrets from fork `pull_request` runs.
- Gated by a `review` environment with required reviewers: each run waits for a maintainer to approve before secrets are released. `allowed_non_write_users: '*'` lets external contributors in, with approval (not an allowlist) as the gate.
- Checks out the PR head so Claude reviews the actual changes. Pinned `actions/checkout@v4` plus `allow-unsafe-pr-checkout: true` to survive the 2026-07-16 fork-checkout default change.
- Setup (already configured): `CLAUDE_CODE_OAUTH_TOKEN` secret, Claude GitHub App, and the `review` environment with required reviewers.

Note: the review self-skips on this PR (`pull_request_target` runs the base branch's copy, which does not exist yet). It starts running on PRs opened after merge.