### PR TITLE
Fix FA4 b19 compatibility and drop the MLA-specific FA4 wrapper

### DIFF
--- a/pithtrain/models/deepseek_v2_lite.py
+++ b/pithtrain/models/deepseek_v2_lite.py
@@ -18,7 +18,7 @@ from pithtrain.layers.factory import ModelImplMode, get_group_linear_cls, get_li
 from pithtrain.models.interface import ForwardAttnOutput
 from pithtrain.modules.load_balance import MoELoadBalanceLossInjector, MoELoadBalanceLossTracker
 from pithtrain.operators.ep_dispatch import moe_ep_prepare_dispatch
-from pithtrain.operators.flash_attn_v4 import mla_flash_attn_func
+from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention import mla_ring_attention_func
 from pithtrain.operators.silu_mul import silu_mul
 from pithtrain.operators.token_scatter import (
@@ -426,15 +426,10 @@ class DeepseekV2LiteAttention(nn.Module):
                 bsz, q_len, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
             )
             k_nope, value_states = torch.split(kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-            attn_output = mla_flash_attn_func(
-                q_nope,
-                q_pe,
-                k_nope,
-                k_pe,
-                value_states,
-                softmax_scale=self.softmax_scale,
-                qk_nope_head_dim=self.qk_nope_head_dim,
-                causal=True,
+            q = torch.cat([q_nope, q_pe], dim=-1)
+            k = torch.cat([k_nope, k_pe.expand(-1, -1, self.num_heads, -1)], dim=-1)
+            attn_output = flash_attn_func(
+                q, k, value_states.contiguous(), softmax_scale=self.softmax_scale, causal=True
             )
 
         attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.v_head_dim)

--- a/pithtrain/operators/flash_attn_v4.py
+++ b/pithtrain/operators/flash_attn_v4.py
@@ -20,7 +20,7 @@ from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
 
 @torch.library.custom_op("pithtrain::flash_attn4_mha_fwd", mutates_args=())
 def _mha_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float, causal: bool) -> Tuple[torch.Tensor, torch.Tensor]:
-    o, lse = _flash_attn_fwd(q, k, v, softmax_scale=softmax_scale, causal=causal, return_lse=True)
+    o, lse, *_ = _flash_attn_fwd(q, k, v, softmax_scale=softmax_scale, causal=causal, return_lse=True)
     return o, lse
 
 @_mha_fwd.register_fake
@@ -55,60 +55,4 @@ _mha_fwd.register_autograd(_mha_backward, setup_context=_mha_setup_context)
 
 def flash_attn_func(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float, causal: bool = False) -> torch.Tensor:
     o, _ = _mha_fwd(q, k, v, softmax_scale, causal)
-    return o
-
-# ---------------------------------------------------------------------------
-# MLA
-#
-# Wraps Q/K concat and FA4 into opaque custom_ops to work around an Inductor
-# SM100 codegen bug that produces NaN on FA4's asymmetric-dim backward.
-# ---------------------------------------------------------------------------
-
-@torch.library.custom_op("pithtrain::flash_attn4_mla_fwd", mutates_args=())
-def _mla_fwd(q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor, k_pe: torch.Tensor, v: torch.Tensor, softmax_scale: float, qk_nope_head_dim: int, causal: bool) -> Tuple[torch.Tensor, torch.Tensor]:
-    q = torch.cat([q_nope, q_pe], dim=-1)
-    k = torch.cat([k_nope, k_pe.expand(-1, -1, q_nope.shape[2], -1)], dim=-1)
-    o, lse = _flash_attn_fwd(q, k, v.contiguous(), softmax_scale=softmax_scale, causal=causal, return_lse=True)
-    return o, lse
-
-@_mla_fwd.register_fake
-def _(q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor, k_pe: torch.Tensor, v: torch.Tensor, softmax_scale: float, qk_nope_head_dim: int, causal: bool):
-    b, s, h, dv = q_nope.shape[0], q_nope.shape[1], q_nope.shape[2], v.shape[-1]
-    o = torch.empty((b, s, h, dv), dtype=q_nope.dtype, device=q_nope.device)
-    lse = torch.empty((b, h, s), dtype=torch.float32, device=q_nope.device)
-    return o, lse
-
-@torch.library.custom_op("pithtrain::flash_attn4_mla_bwd", mutates_args=())
-def _mla_bwd(q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor, k_pe: torch.Tensor, v: torch.Tensor, o: torch.Tensor, lse: torch.Tensor, grad_o: torch.Tensor, softmax_scale: float, qk_nope_head_dim: int, causal: bool) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    h = q_nope.shape[2]
-    q = torch.cat([q_nope, q_pe], dim=-1)
-    k = torch.cat([k_nope, k_pe.expand(-1, -1, h, -1)], dim=-1)
-    dq, dk, dv = _flash_attn_bwd(q, k, v.contiguous(), o, grad_o, lse, softmax_scale=softmax_scale, causal=causal)
-    dq_nope, dq_pe = dq[:, :, :, :qk_nope_head_dim], dq[:, :, :, qk_nope_head_dim:]
-    dq_nope, dq_pe = dq_nope.contiguous(), dq_pe.contiguous()
-    dk_nope, dk_pe = dk[:, :, :, :qk_nope_head_dim], dk[:, :, :, qk_nope_head_dim:]
-    dk_nope, dk_pe = dk_nope.contiguous(), dk_pe.sum(dim=2, keepdim=True)
-    return dq_nope, dq_pe, dk_nope, dk_pe, dv
-
-@_mla_bwd.register_fake
-def _(q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor, k_pe: torch.Tensor, v: torch.Tensor, o: torch.Tensor, lse: torch.Tensor, grad_o: torch.Tensor, softmax_scale: float, qk_nope_head_dim: int, causal: bool):
-    return torch.empty_like(q_nope), torch.empty_like(q_pe), torch.empty_like(k_nope), torch.empty_like(k_pe), torch.empty_like(v)
-
-def _mla_setup_context(ctx: torch.autograd.function.FunctionCtx, inputs: Tuple, output: Tuple) -> None:
-    q_nope, q_pe, k_nope, k_pe, v, softmax_scale, qk_nope_head_dim, causal = inputs
-    o, lse = output
-    ctx.save_for_backward(q_nope, q_pe, k_nope, k_pe, v, o, lse)
-    ctx.softmax_scale = softmax_scale
-    ctx.qk_nope_head_dim = qk_nope_head_dim
-    ctx.causal = causal
-
-def _mla_backward(ctx: torch.autograd.function.FunctionCtx, grad_o: torch.Tensor, grad_lse: torch.Tensor) -> Tuple:
-    q_nope, q_pe, k_nope, k_pe, v, o, lse = ctx.saved_tensors
-    dq_nope, dq_pe, dk_nope, dk_pe, dv = _mla_bwd(q_nope, q_pe, k_nope, k_pe, v, o, lse, grad_o, ctx.softmax_scale, ctx.qk_nope_head_dim, ctx.causal)
-    return dq_nope, dq_pe, dk_nope, dk_pe, dv, None, None, None
-
-_mla_fwd.register_autograd(_mla_backward, setup_context=_mla_setup_context)
-
-def mla_flash_attn_func(q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor, k_pe: torch.Tensor, v: torch.Tensor, softmax_scale: float, qk_nope_head_dim: int, causal: bool = False) -> torch.Tensor:
-    o, _ = _mla_fwd(q_nope, q_pe, k_nope, k_pe, v, softmax_scale, qk_nope_head_dim, causal)
     return o

--- a/pithtrain/operators/ring_attention.py
+++ b/pithtrain/operators/ring_attention.py
@@ -162,12 +162,12 @@ def zigzag_forward(
         if step + 1 < cp_size:
             next_k, next_v, kv_work = post_ring_kv(k, v, cp_group, dst, src)
         if step == 0:
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q, k, v, softmax_scale=sm_scale, causal=True, return_lse=True
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
         elif step <= cp_rank:
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q,
                 k[:, :block],
                 v[:, :block],
@@ -177,7 +177,7 @@ def zigzag_forward(
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
         else:
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q_back, k, v, softmax_scale=sm_scale, causal=False, return_lse=True
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse, start=block)
@@ -498,7 +498,7 @@ def mla_zigzag_forward(
                 normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q, key, value, softmax_scale=sm_scale, causal=True, return_lse=True
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
@@ -512,7 +512,7 @@ def mla_zigzag_forward(
                 **_fp8_kw,
             )
             key = torch.cat([k_nope, k_pe[:, :block].expand(-1, -1, num_heads, -1)], dim=-1)
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q, key, value, softmax_scale=sm_scale, causal=False, return_lse=True
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse)
@@ -521,7 +521,7 @@ def mla_zigzag_forward(
                 normed_kv, kv_b_weight, num_heads, qk_nope_head_dim, v_head_dim, **_fp8_kw
             )
             key = torch.cat([k_nope, k_pe.expand(-1, -1, num_heads, -1)], dim=-1)
-            partial_out, partial_lse = _flash_attn_fwd(
+            partial_out, partial_lse, *_ = _flash_attn_fwd(
                 q_back, key, value, softmax_scale=sm_scale, causal=False, return_lse=True
             )
             out, lse = combine_partial(out, lse, partial_out, partial_lse, start=block)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     "deep-gemm",
-    "flash-attn-4[cu13]>=4.0.0b16",
+    "flash-attn-4[cu13]>=4.0.0b19",
     "flash-linear-attention>=0.5.1",
     "torch>=2.12.0",
     "transformers",

--- a/tests/operators/test_ring_attention.py
+++ b/tests/operators/test_ring_attention.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn.functional as F
 
 from pithtrain.modules.distributed import DistributedCfg, DistributedCtx
-from pithtrain.operators.flash_attn_v4 import flash_attn_func, mla_flash_attn_func
+from pithtrain.operators.flash_attn_v4 import flash_attn_func
 from pithtrain.operators.ring_attention import mla_ring_attention_func, ring_attention_func
 from tests.utilities import cosine_error, launch
 
@@ -164,14 +164,13 @@ def record_mla(ctx: DistributedCtx, req: MLARequest):
     w_r = w_full.clone().requires_grad_(True)
     kv = F.linear(normed_kv_r, w_r).view(req.B, req.S, H, nope + vdim)
     k_nope, value = torch.split(kv, [nope, vdim], dim=-1)
-    out_r = mla_flash_attn_func(
-        q_nope_r,
-        q_pe_r,
-        k_nope.contiguous(),
-        k_pe_r,
+    q_r = torch.cat([q_nope_r, q_pe_r], dim=-1)
+    k_r = torch.cat([k_nope, k_pe_r.expand(-1, -1, H, -1)], dim=-1)
+    out_r = flash_attn_func(
+        q_r,
+        k_r,
         value.contiguous(),
         softmax_scale=softmax_scale,
-        qk_nope_head_dim=nope,
         causal=True,
     )
     out_r.sum().backward()
@@ -289,14 +288,13 @@ def record_mla_fp8(ctx: DistributedCtx, req: MLARequest):
     k_pe_r = k_pe_full.clone().requires_grad_(True)
     kv = ref_lin(normed_kv_r).view(req.B, req.S, H, nope + vdim)
     k_nope, value = torch.split(kv, [nope, vdim], dim=-1)
-    out_r = mla_flash_attn_func(
-        q_nope_r,
-        q_pe_r,
-        k_nope.contiguous(),
-        k_pe_r,
+    q_r = torch.cat([q_nope_r, q_pe_r], dim=-1)
+    k_r = torch.cat([k_nope, k_pe_r.expand(-1, -1, H, -1)], dim=-1)
+    out_r = flash_attn_func(
+        q_r,
+        k_r,
         value.contiguous(),
         softmax_scale=softmax_scale,
-        qk_nope_head_dim=nope,
         causal=True,
     )
     out_r.sum().backward()


### PR DESCRIPTION
## Issues resolved

1. **FA4 b19 4-tuple return.** flash-attention b19 (Dao-AILab/flash-attention#2621, sparse MLA) widened `_flash_attn_fwd`'s return from `(out, lse)` to `(out, lse, p, row_max)`. Every call site in the repo unpacked two values and crashed with `ValueError: too many values to unpack`. Fixed by discarding the extra values at the call site; floor bumped to `flash-attn-4>=4.0.0b19`.

2. **MLA-specific FA4 wrapper removed.** DeepSeek-V2-Lite's non-CP MLA attention used an opaque `mla_flash_attn_func` custom op that boxed the q/k concat + FA4 together, to dodge an Inductor SM100 codegen NaN on FA4's asymmetric-dim backward (torch 2.10 + FA4-b7). That NaN no longer reproduces on the current torch 2.12 + FA4-b19 stack. The concat is now done in the model and fed to `flash_attn_func` directly, so it lives in the `torch.compile` graph. The wrapper (`_mla_fwd`/`_mla_bwd`/`mla_flash_attn_func`) is deleted.

## Correctness (B200, pp2/ep2, real routing) — no NaN

```
2026-06-25 13:46:45 | INFO | step 00000001/00000025 | step-time 57.087 sec | cross-entropy-loss 11.9269 | load-balance-loss 1.035905 | learning-rate 1.000000e-06 | gradient-norm 44.0787 | tokens-per-second 2,296 | peak-gpu-memory 78.11 GB
2026-06-25 13:46:47 | INFO | step 00000002/00000025 | step-time 2.546 sec | cross-entropy-loss 11.9132 | load-balance-loss 1.034085 | learning-rate 1.000000e-06 | gradient-norm 68.2542 | tokens-per-second 51,484 | peak-gpu-memory 78.12 GB
2026-06-25 13:46:50 | INFO | step 00000003/00000025 | step-time 2.488 sec | cross-entropy-loss 11.9035 | load-balance-loss 1.033514 | learning-rate 1.000000e-06 | gradient-norm 67.4410 | tokens-per-second 52,671 | peak-gpu-memory 78.12 GB
2026-06-25 13:46:53 | INFO | step 00000004/00000025 | step-time 2.491 sec | cross-entropy-loss 11.9059 | load-balance-loss 1.032568 | learning-rate 1.000000e-06 | gradient-norm 73.6298 | tokens-per-second 52,610 | peak-gpu-memory 78.12 GB
2026-06-25 13:46:56 | INFO | step 00000005/00000025 | step-time 2.493 sec | cross-entropy-loss 11.8912 | load-balance-loss 1.032724 | learning-rate 1.000000e-06 | gradient-norm 47.0430 | tokens-per-second 52,580 | peak-gpu-memory 78.12 GB
```

## Performance (H100, throughput benchmark)

Moving the MLA concat out of the opaque custom op and into the `torch.compile` graph lets Inductor fuse it with the surrounding attention ops.

**Before** (concat boxed in the custom op):

```
2026-06-23 01:30:40 | INFO | step 00000001/00000025 | step-time 62.105 sec | cross-entropy-loss 11.9881 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 35.6103 | tokens-per-second 33,768 | peak-gpu-memory 39.73 GB
2026-06-23 01:31:04 | INFO | step 00000002/00000025 | step-time 23.277 sec | cross-entropy-loss 11.9855 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 39.1347 | tokens-per-second 90,094 | peak-gpu-memory 47.25 GB
2026-06-23 01:31:28 | INFO | step 00000003/00000025 | step-time 23.475 sec | cross-entropy-loss 11.9792 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 35.4346 | tokens-per-second 89,337 | peak-gpu-memory 47.26 GB
2026-06-23 01:31:51 | INFO | step 00000004/00000025 | step-time 22.993 sec | cross-entropy-loss 11.9767 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 34.9587 | tokens-per-second 91,207 | peak-gpu-memory 47.26 GB
2026-06-23 01:32:15 | INFO | step 00000005/00000025 | step-time 23.685 sec | cross-entropy-loss 11.9684 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 33.3818 | tokens-per-second 88,544 | peak-gpu-memory 47.26 GB
```

**After** (concat in the compiled graph):

```
2026-06-25 14:19:07 | INFO | step 00000001/00000025 | step-time 57.900 sec | cross-entropy-loss 11.9897 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 36.6775 | tokens-per-second 36,220 | peak-gpu-memory 39.72 GB
2026-06-25 14:19:30 | INFO | step 00000002/00000025 | step-time 21.952 sec | cross-entropy-loss 11.9874 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 29.3726 | tokens-per-second 95,533 | peak-gpu-memory 47.25 GB
2026-06-25 14:19:52 | INFO | step 00000003/00000025 | step-time 22.029 sec | cross-entropy-loss 11.9779 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 28.8567 | tokens-per-second 95,201 | peak-gpu-memory 47.25 GB
2026-06-25 14:20:15 | INFO | step 00000004/00000025 | step-time 21.900 sec | cross-entropy-loss 11.9726 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 28.6510 | tokens-per-second 95,760 | peak-gpu-memory 47.26 GB
2026-06-25 14:20:37 | INFO | step 00000005/00000025 | step-time 21.900 sec | cross-entropy-loss 11.9699 | load-balance-loss 1.000000 | learning-rate 1.000000e-06 | gradient-norm 37.7204 | tokens-per-second 95,759 | peak-gpu-memory 47.26 GB
```

Median throughput over steps 3–5 (warmup/compile excluded):

| | tokens/sec |
|---|---|
| Before | 89,337 |
| After | 95,759 |
| **Speedup** | **+7.2%** |
