### PR TITLE
Show Full Output in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,3 +28,4 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'
+          show_full_output: true


### PR DESCRIPTION
Surface the review agent's full transcript in the Actions log instead of the redacted "output hidden for security" placeholder, so review runs that finish without posting a comment can be diagnosed.