### PR TITLE
Pin fast-moving dependencies and bound torch below 2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,15 @@ name = "pithtrain"
 version = "0.1.3"
 license = "Apache-2.0"
 requires-python = ">=3.12"
-dependencies = ["deep-gemm", "flash-attn-4[cu13]>=4.0.0b20", "flash-linear-attention>=0.5.1", "torch>=2.12.0", "transformers", "wandb", "zstandard"]
+dependencies = [
+    "torch>=2.13.0,<2.14",
+    "deep-gemm",
+    "flash-attn-4[cu13]==4.0.0b28",
+    "flash-linear-attention==0.5.2",
+    "transformers",
+    "wandb",
+    "zstandard",
+]
 
 [dependency-groups]
 dev = ["pre-commit", "pytest", "ruff"]
@@ -16,7 +24,6 @@ requires = ["setuptools>=61"]
 include = ["pithtrain*"]
 
 [tool.uv]
-prerelease = "allow"
 environments = ["sys_platform == 'linux'"]
 
 [[tool.uv.index]]
@@ -25,11 +32,11 @@ url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [tool.uv.sources]
-deep-gemm = { git = "https://github.com/deepseek-ai/DeepGEMM", branch = "main" }
+deep-gemm = { git = "https://github.com/deepseek-ai/DeepGEMM", rev = "559d79fb6994a58b8a15b4b93bf13ccc16edf247" }
 torch = { index = "torch-cu130" }
 
 [tool.uv.extra-build-dependencies]
-deep-gemm = ["torch>=2.12.0", "packaging", "setuptools", "wheel"]
+deep-gemm = ["torch>=2.13.0,<2.14", "packaging", "setuptools", "wheel"]
 
 [tool.uv.extra-build-variables]
 deep-gemm = { DG_FORCE_BUILD = "1", DG_USE_LOCAL_VERSION = "0" }


### PR DESCRIPTION
- torch: >=2.12.0 resolved to 2.14.0, which is on the cu130 index but has no
  upstream git tag. Its headers need C++20, and deep-gemm hardcodes
  -std=c++17, so the extension fails to compile. 2.12.1 and 2.13.0 both build;
  only 2.14 fails. Now >=2.13.0,<2.14.
- deep-gemm: tracked branch=main, so the built extension could change under us.
  Pinned to the current main SHA.
- fa4, fla: ship breaking changes between releases; pinned exactly.
- Dropped prerelease="allow" -- not needed for fa4, since ==4.0.0b28 permits
  its own prerelease, and it was admitting prereleases of unrelated packages
  (97 -> 95 resolved packages).

Verified from a cleaned cache and no lockfile: deep-gemm compiles, imports
succeed, 8-rank NCCL all-reduce is correct, FA4 forward/backward ~1.6s each.