### PR TITLE
Read ep_rank from the distributed context when resharding expert weights

### DIFF
--- a/pithtrain/modules/checkpoint.py
+++ b/pithtrain/modules/checkpoint.py
@@ -18,6 +18,8 @@ import torch.nn as nn
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Shard
 
+from pithtrain.contexts import distributed
+
 __all__ = ["to_canonical_model", "to_canonical_optim", "to_localized_model", "to_localized_optim"]
 
 MODULE_PREFIX_RE = re.compile(r"^module\.\d+\.")
@@ -43,14 +45,14 @@ def find_moe(key: str, named_modules: Dict[str, nn.Module]) -> Optional[nn.Modul
     if after and after.split(".")[0].isdigit():
         return None
     mod = named_modules.get(moe_path)
-    if mod and hasattr(mod, "ep_rank") and hasattr(mod, "experts_per_rank"):
+    if mod and hasattr(mod, "experts_per_rank"):
         return mod
     return None
 
 
 def expert_range(mod: nn.Module) -> Tuple[int, int]:
     """Global expert index range [start, end) for this EP rank."""
-    start = mod.ep_rank * mod.experts_per_rank
+    start = distributed.ep_rank * mod.experts_per_rank
     return start, start + mod.experts_per_rank
 
 
@@ -172,7 +174,7 @@ def repack(
             if local is not None:
                 moe_path = local.partition(".experts.")[0]
                 moe = named_modules.get(moe_path)
-                if moe and hasattr(moe, "ep_rank"):
+                if moe and hasattr(moe, "experts_per_rank"):
                     s, e = expert_range(moe)
                     idx = int(idx_str)
                     if s <= idx < e:


### PR DESCRIPTION
## Read ep_rank from the distributed context when resharding expert weights

Supersedes #82, which fixed the same bug by putting `ep_rank` back on every MoE module. Per the discussion there, this goes the other way: #70 moved `ep_rank` onto the process-global `contexts`, so `checkpoint.py` reads it from there instead. Save and load both run after the contexts are initialized, so `distributed.ep_rank` is always set.

### The bug

`find_moe` gated on `hasattr(mod, "ep_rank")`, which no module sets any more, so it always returned `None`. Expert weights were never localized to the EP rank and loading an HF-converted checkpoint at ep>1 failed with `Missing key in checkpoint state_dict: app.model.layers.0.mlp.experts.gate_proj.weight`. `experts_per_rank` is still on the module and is just as discriminating a marker, so the dropped check costs nothing.

### Verification

Save/load round trip on deepseek-v2-lite, one node, pp=2 ep=4 (16 shards, 176 GB):

- save leg: from scratch, steps 1-2, checkpoint written at step-00000002
- load leg: `Load checkpoint: step-00000002`, then resumed at **step 3**, not step 1
- loss continued 11.82 → 11.40 → 11.19; a failed weight load restarts near the random-init 11.94
- LR continued along the warmup ramp, so step and scheduler state came back too
