### PR TITLE
Rendezvous the launchers through c10d instead of a static node rank

### DIFF
--- a/.agents/skills/capture-nsys-profile/scripts/launch_capture.sh
+++ b/.agents/skills/capture-nsys-profile/scripts/launch_capture.sh
@@ -20,8 +20,7 @@ NSYS_ARGS+=(--capture-range-end=stop-shutdown)
 NSYS_ARGS+=(--delay=0)
 
 TORCHRUN_ARGS=()
-TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
 nsys ${NSYS_ARGS[@]} torchrun ${TORCHRUN_ARGS[@]} $SCRIPT $@

--- a/.agents/skills/validate-correctness/scripts/launch.sh
+++ b/.agents/skills/validate-correctness/scripts/launch.sh
@@ -6,8 +6,7 @@ export OMP_NUM_THREADS=8
 export PYTHONUNBUFFERED=1
 
 TORCHRUN_ARGS=()
-TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
 torchrun ${TORCHRUN_ARGS[@]} $1

--- a/benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/pp1-dp1-cp1-ep8-seq2048-bf16.sh
+++ b/benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/pp1-dp1-cp1-ep8-seq2048-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/pp1-dp1-cp1-ep8-seq2048-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/deepseek-v2-lite/h100-1n8g/pp1-dp1-cp1-ep8-seq2048-bf16.py

--- a/benchmarks/pretraining/gpt-oss-120b/h100-8n8g/pp8-dp1-cp1-ep8-seq2048-bf16.sh
+++ b/benchmarks/pretraining/gpt-oss-120b/h100-8n8g/pp8-dp1-cp1-ep8-seq2048-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/gpt-oss-120b/h100-8n8g/pp8-dp1-cp1-ep8-seq2048-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/gpt-oss-120b/h100-8n8g/pp8-dp1-cp1-ep8-seq2048-bf16.py

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq2048-bf16.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq2048-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq2048-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq2048-bf16.py

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq4096-bf16.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq4096-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq4096-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq4096-bf16.py

--- a/benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/pp4-dp2-cp1-ep8-seq4096-bf16.sh
+++ b/benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/pp4-dp2-cp1-ep8-seq4096-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/pp4-dp2-cp1-ep8-seq4096-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/qwen3-30b-a3b/h100-8n8g/pp4-dp2-cp1-ep8-seq4096-bf16.py

--- a/benchmarks/pretraining/qwen3.5-35b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq1536-bf16.sh
+++ b/benchmarks/pretraining/qwen3.5-35b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq1536-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/qwen3.5-35b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq1536-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/qwen3.5-35b-a3b/h100-2n8g/pp2-dp1-cp1-ep8-seq1536-bf16.py

--- a/benchmarks/pretraining/qwen3.5-35b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq3072-bf16.sh
+++ b/benchmarks/pretraining/qwen3.5-35b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq3072-bf16.sh
@@ -3,9 +3,8 @@
 
 set -euo pipefail
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
-torchrun ${TRUN_ARGS[@]} benchmarks/pretraining/qwen3.5-35b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq3072-bf16.py
+torchrun ${TORCHRUN_ARGS[@]} benchmarks/pretraining/qwen3.5-35b-a3b/h100-4n8g/pp4-dp1-cp1-ep8-seq3072-bf16.py

--- a/examples/pretrain_lm/launch.sh
+++ b/examples/pretrain_lm/launch.sh
@@ -18,14 +18,13 @@ if [ $# -ne 1 ]; then
 fi
 
 # Setup distributed.
-LAUNCH_ARGS=()
-LAUNCH_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
-RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
-LAUNCH_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$RDZV_HOST:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --nproc-per-node=gpu)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1):15213)
 
 # Launch the training.
 SCRIPT=examples/pretrain_lm/$1/script.py
 OUTPUT=logging/pretrain_lm/${1}_node${SLURM_NODEID:-0}.log
 
 mkdir -p $(dirname $OUTPUT) && exec > >(tee $OUTPUT) 2>&1
-torchrun ${LAUNCH_ARGS[@]} $SCRIPT
+torchrun ${TORCHRUN_ARGS[@]} $SCRIPT

--- a/tests/test_dualpipev.sh
+++ b/tests/test_dualpipev.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 export WORKSPACE=$(readlink -f ${WORKSPACE:-$PWD/workspace})
 export OMP_NUM_THREADS=8
 
-TRUN_ARGS=()
-TRUN_ARGS+=(--nnodes=1 --nproc-per-node=8)
-TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=localhost:15213)
+TORCHRUN_ARGS=()
+TORCHRUN_ARGS+=(--nnodes=1 --nproc-per-node=8)
+TORCHRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=localhost:15213)
 
 MODEL="${1:-examples/pretrain_lm/deepseek-v2-lite/config.json}"
 
@@ -20,4 +20,4 @@ SCRIPT=tests/test_dualpipev.py
 TAG=$(basename "$(dirname "$MODEL")")
 OUTPUT=$PWD/logging/test_dualpipev_${TAG}.log; mkdir -p $(dirname $OUTPUT)
 
-torchrun ${TRUN_ARGS[@]} $SCRIPT ${MAIN_ARGS[@]} 2>&1 | tee $OUTPUT
+torchrun ${TORCHRUN_ARGS[@]} $SCRIPT ${MAIN_ARGS[@]} 2>&1 | tee $OUTPUT


### PR DESCRIPTION
## Why

Every launcher built a static rendezvous by hand:

```bash
TRUN_ARGS+=(--nnodes=${SLURM_NNODES:-1} --node-rank=${SLURM_NODEID:-0} --nproc-per-node=gpu)
RDZV_HOST=$(scontrol show hostnames "${SLURM_STEP_NODELIST:-localhost}" | head -1 || echo localhost)
```

`scontrol` was not installed in the container image, so on every node the pipeline failed, `set -o pipefail` made the `||` branch fire, and `RDZV_HOST` became `localhost`. Each node then rendezvoused with itself and formed its own world of one. Multi-node runs hung at startup rather than failing, and the fallback that was supposed to make the line safe is what hid the fault.

`--node-rank` was inert regardless. torchrun honours it only when the rendezvous backend is static, so it had no effect on any run that used c10d, and nothing in the benchmarks depends on it — c10d assigns ranks from the sorted set of participating nodes, which is already a deterministic function of hostname.

## Changes

Eleven launchers, +82/-92.

| change | why |
|---|---|
| Drop `--node-rank` | Inert under c10d, and c10d's rank assignment is already deterministic |
| Set `--rdzv-backend=c10d` with the endpoint inlined | One expression instead of a variable plus a fallback that could silently win |
| Drop `\|\| echo localhost` | A rendezvous host that cannot be resolved should fail the step, not degrade to a hang |
| `TRUN_ARGS` / `LAUNCH_ARGS` -> `TORCHRUN_ARGS` | Three names for one array; the surviving one names the command whose flags it holds |

Out of tree: the container image now ships `slurm-client`, so `scontrol` resolves nodelists inside the step. That is the prerequisite the old fallback existed to paper over.

`tests/test_dualpipev.sh` and `benchmarks/operators/bench_ring_attention.sh` keep their hardcoded `localhost:15213` — both are single-node and were never affected.

## Evidence

The committed `TORCHRUN_ARGS` lines, run verbatim as a 2-node step:

```
[node <host-b>] TORCHRUN_ARGS=--nnodes=2 --nproc-per-node=gpu --rdzv-backend=c10d --rdzv-endpoint=<host-a>:15213
[node <host-a>] TORCHRUN_ARGS=--nnodes=2 --nproc-per-node=gpu --rdzv-backend=c10d --rdzv-endpoint=<host-a>:15213
GATE PASS world_size=16 nodes=2
srun exit=0
```

Both nodes resolve the same endpoint independently (hostnames replaced with placeholders), and the 16 ranks agree on an `all_reduce` whose result is checked rather than assumed. torchrun emits a `RendezvousConnectionError` from the non-host node during teardown after the collective completes; it does not affect the exit status.

| check | result |
|---|---|
| 2-node launcher pattern, 16 ranks | `GATE PASS`, `srun exit=0` |
| 4-node `all_reduce`, 32 ranks | `all_reduce=496.0`, `Using network IB` on all 8 `mlx5` HCAs |
| `tests/test_dualpipev.sh` (single-node path) | All gradients match the reference, max diff `6.76e-4` |

The old nodelist expansion was also checked against `scontrol` on 225 generated nodelist expressions before being replaced; all 225 agreed. That work is moot now that `scontrol` is present, and is noted only because it is why the parser is gone rather than fixed.
